### PR TITLE
fix: Add TimerOption to __init__.py

### DIFF
--- a/click_extra/__init__.py
+++ b/click_extra/__init__.py
@@ -76,6 +76,7 @@ from .tabulate import table_format_option  # isort:skip
 
 # Import last to avoid circular dependencies.
 from .commands import (  # isort:skip
+    TimerOption,
     extra_command,
     extra_group,
     timer_option,


### PR DESCRIPTION
This wants to be here yes? Otherwise, this test script fails:
```python
import click_extra
@click_extra.extra_command(params=[
  click_extra.TimerOption(),
  click_extra.ColorOption(),
  click_extra.ConfigOption(),
  click_extra.ShowParamsOption(),
  click_extra.VerbosityOption(),
  click_extra.VersionOption(print_env_info=True),
  click_extra.HelpOption(),
])
def cli():
  print("works!")

cli()
```
with:
```text
Traceback (most recent call last):
  File "C:\issue320.py", line 3, in <module>
    click_extra.TimerOption(),
AttributeError: module 'click_extra' has no attribute 'TimerOption'. Did you mean: 'timer_option'?
```