### PR TITLE
Add `colored_command` and `colored_group` decorators

### DIFF
--- a/click_extra/__init__.py
+++ b/click_extra/__init__.py
@@ -46,6 +46,8 @@ from .decorators import (  # type: ignore[no-redef] # noqa: I001, E402, F401
     config_option,
     extra_command,
     extra_group,
+    colored_command,
+    colored_group,
     group,  # noqa: E402
     help_option,
     show_params_option,
@@ -100,6 +102,8 @@ __all__ = [  # noqa: F405
     "edit",
     "extra_command",
     "extra_group",
+    "colored_command",
+    "colored_group",
     "ExtraOption",
     "File",
     "file_path",

--- a/click_extra/decorators.py
+++ b/click_extra/decorators.py
@@ -102,6 +102,14 @@ def default_extra_params():
     ]
 
 
+def minimal_extra_params():
+    """Minimal options added to ``extra_command`` and ``extra_group``:
+
+    #. ``-h``, ``--help``
+    """
+    return [HelpOption()]
+
+
 # Redefine cloup decorators to allow them to be used with or without parenthesis.
 command = decorator_factory(dec=cloup.command)
 group = decorator_factory(dec=cloup.group)
@@ -112,6 +120,14 @@ extra_command = decorator_factory(
 )
 extra_group = decorator_factory(
     dec=cloup.group, cls=ExtraGroup, params=default_extra_params
+)
+
+# Colored command and group decorators with minimal options.
+colored_command = decorator_factory(
+    dec=cloup.command, cls=ExtraCommand, params=minimal_extra_params
+)
+colored_group = decorator_factory(
+    dec=cloup.group, cls=ExtraGroup, params=minimal_extra_params
 )
 
 

--- a/click_extra/tests/test_commands.py
+++ b/click_extra/tests/test_commands.py
@@ -83,6 +83,7 @@ def test_module_root_declarations():
         click_members.union(cloup_members).union(click_extra_members),
         key=lambda m: (m.lower(), m),
     )
+    click_extra_members = sorted(click_extra_members, key=str.casefold)
     assert expected_members == click_extra_members
 
 


### PR DESCRIPTION
These decorators are for colorizing help output without extra options.