### PR TITLE
Fallback `package_name` to file name for standalone scripts

### DIFF
--- a/click_extra/version.py
+++ b/click_extra/version.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import inspect
 import logging
 import re
+import os
 import warnings
 from functools import cached_property
 from gettext import gettext as _
@@ -170,6 +171,10 @@ class ExtraVersionOption(ExtraOption):
                 package_name = frame.f_globals.get("__package__")
                 if package_name:
                     package_name = package_name.split(".")[0]
+                    break
+                package_name = frame.f_globals.get("__file__")
+                if package_name:
+                    (_, package_name) = os.path.split(package_name)
 
             break
 


### PR DESCRIPTION
See also #724, which can be closed.

**Edit**: Please note that some examples still fail, such as the tutorial page’s 2nd example:
```python
from click_extra import extra_command, echo, option

@extra_command
@option("--count", default=1, help="Number of greetings.")
@option("--name", prompt="Your name", help="The person to greet.")
def hello(count, name):
    """Simple program that greets NAME for a total of COUNT times."""
    for _ in range(count):
        echo(f"Hello, {name}!")
```
but this fails under plain click as well. 

To fix these failures, we would need to define a default version value, such as `n/a`, instead of raising an exception.