### PR TITLE
fix(deps): bump cloup to 3.0.7

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -178,7 +178,7 @@ typing = [
 requires-dist = [
     { name = "boltons", specifier = "~=25.0.0" },
     { name = "click", git = "https://github.com/kdeldycke/click.git?rev=flag_normalization" },
-    { name = "cloup", specifier = "~=3.0.5" },
+    { name = "cloup", specifier = "~=3.0.7" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'test'", specifier = "~=7.9.1" },
     { name = "extra-platforms", specifier = ">=3.1.0" },
     { name = "extra-platforms", extras = ["pytest"], marker = "extra == 'test'", specifier = ">=3.1.0" },


### PR DESCRIPTION
With cloup 3.0.5, I got this error on Ubuntu 24.04:
```
  File "/home/ross/.local/lib/python3.12/site-packages/click/core.py", line 1442, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ross/.local/lib/python3.12/site-packages/click_extra/commands.py", line 353, in main
    return super().main(args=args, prog_name=prog_name, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ross/.local/lib/python3.12/site-packages/click/core.py", line 1362, in main
    with self.make_context(prog_name, args, **extra) as ctx:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ross/.local/lib/python3.12/site-packages/click_extra/commands.py", line 377, in make_context
    return super().make_context(info_name, args, parent, **extra)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ross/.local/lib/python3.12/site-packages/click/core.py", line 1186, in make_context
    self.parse_args(ctx, args)
  File "/home/ross/.local/lib/python3.12/site-packages/cloup/constraints/_support.py", line 183, in parse_args
    args = super().parse_args(ctx, args)  # type: ignore
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ross/.local/lib/python3.12/site-packages/click/core.py", line 1197, in parse_args
    value, args = param.handle_parse_result(ctx, opts, args)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ross/.local/lib/python3.12/site-packages/click/core.py", line 2416, in handle_parse_result
    value = self.process_value(ctx, value)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ross/.local/lib/python3.12/site-packages/click/core.py", line 2355, in process_value
    value = self.callback(ctx, self, value)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ross/.local/lib/python3.12/site-packages/click/decorators.py", line 539, in show_help
    echo(ctx.get_help(), color=ctx.color)
         ^^^^^^^^^^^^^^
  File "/home/ross/.local/lib/python3.12/site-packages/click/core.py", line 730, in get_help
    return self.command.get_help(self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ross/.local/lib/python3.12/site-packages/click_extra/colorize.py", line 429, in get_help
    return super().get_help(ctx)  # type: ignore[no-any-return,misc]
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/ross/.local/lib/python3.12/site-packages/click/core.py", line 1064, in get_help
    self.format_help(ctx, formatter)
  File "/home/ross/.local/lib/python3.12/site-packages/click_extra/colorize.py", line 445, in format_help
    super().format_help(ctx, formatter)  # type: ignore[misc]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ross/.local/lib/python3.12/site-packages/cloup/_commands.py", line 108, in format_help
    self.format_params(ctx, formatter)
  File "/home/ross/.local/lib/python3.12/site-packages/cloup/_option_groups.py", line 257, in format_params
    positional_arguments_section = self.get_arguments_help_section(ctx)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ross/.local/lib/python3.12/site-packages/cloup/_option_groups.py", line 200, in get_arguments_help_section
    self.get_argument_help_record(arg, ctx) for arg in self.arguments
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ross/.local/lib/python3.12/site-packages/cloup/_option_groups.py", line 190, in get_argument_help_record
    return arg.get_help_record(ctx)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ross/.local/lib/python3.12/site-packages/cloup/_params.py", line 13, in get_help_record
    return self.make_metavar(), self.help or ""
           ^^^^^^^^^^^^^^^^^^^
```
I didn't test 3.0.6.