### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -9,11 +9,11 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-06T20:02:03.713345681Z"
+exclude-newer = "2026-04-07T10:58:21.914178064Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
-pytest = { timestamp = "2026-04-13T20:02:03.713351162Z", span = "PT0S" }
+pytest = { timestamp = "2026-04-14T10:58:21.914183866Z", span = "PT0S" }
 
 [[package]]
 name = "accessible-pygments"
@@ -545,7 +545,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1374,14 +1374,14 @@ wheels = [
 
 [[package]]
 name = "types-pygments"
-version = "2.20.0.20260406"
+version = "2.20.0.20260407"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "types-docutils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/bd/d17c28a4c65c556bc4c4bc8f363aa2fbfc91b397e3c0019839d74d9ead31/types_pygments-2.20.0.20260406.tar.gz", hash = "sha256:d3ed7ecd7c34a382459d28ce624b87e1dee03d6844e43aa7590ef4b8c7c9dfce", size = 19486, upload-time = "2026-04-06T04:33:59.632Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/a7/97ec1f3267736c32b9a8795f602e0efad1f72c922c1d29e1a1dc4d9b189e/types_pygments-2.20.0.20260407.tar.gz", hash = "sha256:57afab71ba7445ea095a395bc8bf66fbec32512d31ecbf4fb2f1d50449287e46", size = 21072, upload-time = "2026-04-07T04:22:52.874Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/00/dca7518e6f99ce0f235ec1c6512593ee4bd25109ae1c912bf9ee836a26e1/types_pygments-2.20.0.20260406-py3-none-any.whl", hash = "sha256:6bb0c79874c304977e1c097f7007140e16fe78c443329154db803d7910d945b3", size = 27278, upload-time = "2026-04-06T04:33:58.744Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/fa/45955cb0beb01dcc6af8ba6ed85f56617126b9edd2fd2d536498b85d07e8/types_pygments-2.20.0.20260407-py3-none-any.whl", hash = "sha256:1595310e36b9a6de63865cd250c3779f3067edfaee4972ae2638d86712537092", size = 29055, upload-time = "2026-04-07T04:22:51.66Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-04-07`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [types-pygments](https://pypi.org/project/types-pygments/) | `2.20.0.20260406` -> `2.20.0.20260407` | 2026-04-07 |

### Release notes

<details>
<summary>python/typeshed (<code>types-pygments</code>)</summary>

[Changelog](https://redirect.github.com/typeshed-internal/stub_uploader/blob/main/data/changelogs/Pygments.md)

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#toolrepomatic-configuration) options:

```toml
[tool.repomatic]
uv-lock.sync = true
```


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`a62776cd`](https://github.com/kdeldycke/click-extra/commit/a62776cd89e52db5daaba7b0d6042b5f7b7df68c) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/click-extra/blob/a62776cd89e52db5daaba7b0d6042b5f7b7df68c/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/a62776cd89e52db5daaba7b0d6042b5f7b7df68c/.github/workflows/autofix.yaml) |
| **Run** | [#2581.1](https://github.com/kdeldycke/click-extra/actions/runs/24395204018) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.12.0`