### PR TITLE
Fix changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,9 @@
 
 ## [`7.11.0` (2026-04-13)](https://github.com/kdeldycke/click-extra/compare/v7.10.1...v7.11.0)
 
+> [!NOTE]
+> `7.11.0` is available on [🐍 PyPI](https://pypi.org/project/click-extra/7.11.0/) and [🐙 GitHub](https://github.com/kdeldycke/click-extra/releases/tag/v7.11.0).
+
 - Add `serialize_data()` and `print_data()` functions for serializing arbitrary nested Python data (not just tabular rows) to JSON, HJSON, TOML, YAML, and XML. Complements the existing `render_table()`/`print_table()` pair.
 - Add `sort_key` parameter to `render_table()` and `print_table()` for pre-render row sorting.
 - Catch `ImportError` from missing optional dependencies in `print_table()` and `print_data()`, producing a clean one-line error instead of a traceback. The `print_data()` `package` parameter lets downstream projects customize install instructions.


### PR DESCRIPTION
### Description

Fixes changelog release dates and updates availability admonitions.

### Configuration

Relevant [`[tool.repomatic]`](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#toolrepomatic-configuration) options:

```toml
[tool.repomatic]
pypi-package-history = ["old-package-name"]
```


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `schedule` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`a62776cd`](https://github.com/kdeldycke/click-extra/commit/a62776cd89e52db5daaba7b0d6042b5f7b7df68c) |
| **Job** | [`fix-changelog`](https://github.com/kdeldycke/click-extra/blob/a62776cd89e52db5daaba7b0d6042b5f7b7df68c/.github/workflows/changelog.yaml) |
| **Workflow** | [`changelog.yaml`](https://github.com/kdeldycke/click-extra/blob/a62776cd89e52db5daaba7b0d6042b5f7b7df68c/.github/workflows/changelog.yaml) |
| **Run** | [#1115.1](https://github.com/kdeldycke/click-extra/actions/runs/24440022590) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.12.0`