### PR TITLE
Format Python

### DIFF
--- a/click_extra/__init__.py
+++ b/click_extra/__init__.py
@@ -78,6 +78,7 @@ from .decorators import (  # type: ignore[no-redef]
     verbosity_option,
     version_option,
 )
+from .jobs import CPU_COUNT, DEFAULT_JOBS, JobsOption
 from .logging import (
     ExtraFormatter,
     ExtraStreamHandler,
@@ -95,7 +96,6 @@ from .parameters import (
     ShowParamsOption,
     search_params,
 )
-from .jobs import DEFAULT_JOBS, CPU_COUNT, JobsOption
 from .table import (
     SortByOption,
     TableFormat,
@@ -113,6 +113,8 @@ from .version import ExtraVersionOption
 
 __all__ = [
     "BOOL",
+    "CPU_COUNT",
+    "DEFAULT_JOBS",
     "DEFAULT_SUBCOMMANDS_KEY",
     "FLOAT",
     "INT",
@@ -128,7 +130,6 @@ __all__ = [
     "BadArgumentUsage",
     "BadOptionUsage",
     "BadParameter",
-    "CPU_COUNT",
     "Choice",
     "ChoiceSource",
     "ClickException",
@@ -140,7 +141,6 @@ __all__ = [
     "ConfigOption",
     "ConstraintMixin",
     "Context",
-    "DEFAULT_JOBS",
     "DateTime",
     "EnumChoice",
     "ExtraCliRunner",


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`455deef0`](https://github.com/kdeldycke/click-extra/commit/455deef080055d17fe5d550ded9143a0cdf3d222) |
| **Job** | [`format-python`](https://github.com/kdeldycke/click-extra/blob/455deef080055d17fe5d550ded9143a0cdf3d222/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/455deef080055d17fe5d550ded9143a0cdf3d222/.github/workflows/autofix.yaml) |
| **Run** | [#2589.1](https://github.com/kdeldycke/click-extra/actions/runs/24452745897) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.13.0`