### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-08T16:56:55.510467905Z"
+exclude-newer = "2026-04-08T17:02:45.501619178Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -542,7 +542,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

### Configuration

Relevant [`[tool.repomatic]`](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#toolrepomatic-configuration) options:

```toml
[tool.repomatic]
uv-lock.sync = true
```


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`3b7dd5e3`](https://github.com/kdeldycke/click-extra/commit/3b7dd5e3e6f387371fabf6753074e89d33380571) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/click-extra/blob/3b7dd5e3e6f387371fabf6753074e89d33380571/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/3b7dd5e3e6f387371fabf6753074e89d33380571/.github/workflows/autofix.yaml) |
| **Run** | [#2594.1](https://github.com/kdeldycke/click-extra/actions/runs/24467456656) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.13.0`