### PR TITLE
Format Python

### DIFF
--- a/click_extra/cli.py
+++ b/click_extra/cli.py
@@ -26,7 +26,6 @@ from . import (
     Choice,
     ClickException,
     Color,
-    __version__,
     argument,
     echo,
     group,

--- a/click_extra/pygments.py
+++ b/click_extra/pygments.py
@@ -127,7 +127,7 @@ _PALETTE_256.update({
 })
 # Grayscale ramp (indices 232-255).
 _PALETTE_256.update({
-    232 + i: "#{0:02x}{0:02x}{0:02x}".format(10 * i + 8) for i in range(24)
+    232 + i: f"#{10 * i + 8:02x}{10 * i + 8:02x}{10 * i + 8:02x}" for i in range(24)
 })
 
 
@@ -591,9 +591,7 @@ LEXER_MAP: dict[type[Lexer], type[Lexer]] = {}
 # Auto-generate the ANSI variant of all session lexers.
 for _original_lexer in collect_session_lexers():
     _new_name = f"Ansi{_original_lexer.__name__}"
-    _new_lexer = _AnsiSessionMeta(
-        _new_name, (_AnsiFilterMixin, _original_lexer), {}
-    )
+    _new_lexer = _AnsiSessionMeta(_new_name, (_AnsiFilterMixin, _original_lexer), {})
     locals()[_new_name] = _new_lexer
     LEXER_MAP[_original_lexer] = _new_lexer
 

--- a/tests/test_pygments.py
+++ b/tests/test_pygments.py
@@ -38,16 +38,16 @@ from pygments.token import Text, Token
 from click_extra import pygments as extra_pygments
 from click_extra.colorize import _nearest_256
 from click_extra.pygments import (
-    LEXER_MAP,
-    AnsiColorLexer,
-    AnsiFilter,
-    AnsiHtmlFormatter,
-    DEFAULT_TOKEN_TYPE,
     _ANSI_STYLES,
     _NAMED_COLORS,
     _PALETTE_256,
-    _token_from_state,
+    DEFAULT_TOKEN_TYPE,
+    LEXER_MAP,
     Ansi,
+    AnsiColorLexer,
+    AnsiFilter,
+    AnsiHtmlFormatter,
+    _token_from_state,
     collect_session_lexers,
 )
 
@@ -832,8 +832,14 @@ def test_ansi_styles_excludes_all_attributes():
     styling is handled by ``EXTRA_ANSI_CSS`` / ``custom.css`` instead.
     """
     for attr in (
-        "Bold", "Faint", "Italic", "Underline", "Blink",
-        "Reverse", "Strikethrough", "Overline",
+        "Bold",
+        "Faint",
+        "Italic",
+        "Underline",
+        "Blink",
+        "Reverse",
+        "Strikethrough",
+        "Overline",
     ):
         assert getattr(Ansi, attr) not in _ANSI_STYLES
 


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`214d60bf`](https://github.com/kdeldycke/click-extra/commit/214d60bffa055af51fc47002f263f497822b8a60) |
| **Job** | [`format-python`](https://github.com/kdeldycke/click-extra/blob/214d60bffa055af51fc47002f263f497822b8a60/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/214d60bffa055af51fc47002f263f497822b8a60/.github/workflows/autofix.yaml) |
| **Run** | [#2600.1](https://github.com/kdeldycke/click-extra/actions/runs/24478006321) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.13.0`