### PR TITLE
Format Python

### DIFF
--- a/click_extra/pygments.py
+++ b/click_extra/pygments.py
@@ -151,7 +151,9 @@ _SGR_FG_COLORS: dict[int, str] = {
 }
 """SGR foreground color codes (30-37, 90-97) to named color strings."""
 
-_SGR_BG_COLORS: dict[int, str] = {code + 10: name for code, name in _SGR_FG_COLORS.items()}
+_SGR_BG_COLORS: dict[int, str] = {
+    code + 10: name for code, name in _SGR_FG_COLORS.items()
+}
 """SGR background color codes (40-47, 100-107) to named color strings.
 
 Derived from ``_SGR_FG_COLORS`` by offsetting each code by +10.
@@ -627,11 +629,14 @@ class AnsiHtmlFormatter(HtmlFormatter):
             return cached
         classes: str = super()._get_css_classes(ttype)  # type: ignore[misc]
         if ttype[0] == "Ansi":
-            classes += " " + " ".join(
-                self._get_css_class(  # type: ignore[attr-defined]
-                    getattr(Ansi, part),
+            classes += (
+                " "
+                + " ".join(
+                    self._get_css_class(  # type: ignore[attr-defined]
+                        getattr(Ansi, part),
+                    )
+                    for part in ttype[1:]
                 )
-                for part in ttype[1:]
             )
         self._ansi_css_cache[ttype] = classes
         return classes

--- a/click_extra/version.py
+++ b/click_extra/version.py
@@ -649,9 +649,8 @@ class ExtraVersionOption(ExtraOption):
         # the user's module, producing false-positive lookups. ``__main__``
         # modules are always entry points (never CliRunner artifacts), so
         # they are exempt from the exclusion.
-        is_main_entry = (
-            self.module_name == "__main__"
-            or self.module_name.endswith(".__main__")
+        is_main_entry = self.module_name == "__main__" or self.module_name.endswith(
+            ".__main__"
         )
         if (
             version is None


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`bcf8fb51`](https://github.com/kdeldycke/click-extra/commit/bcf8fb5116bd1c34be46d1189b048f287f3dcd66) |
| **Job** | [`format-python`](https://github.com/kdeldycke/click-extra/blob/bcf8fb5116bd1c34be46d1189b048f287f3dcd66/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/bcf8fb5116bd1c34be46d1189b048f287f3dcd66/.github/workflows/autofix.yaml) |
| **Run** | [#2607.1](https://github.com/kdeldycke/click-extra/actions/runs/24494149566) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.13.0`