### PR TITLE
Bump minor version to `v7.13.0`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [`7.12.1.dev0` (unreleased)](https://github.com/kdeldycke/click-extra/compare/v7.12.0...main)
+## [`7.13.0.dev0` (unreleased)](https://github.com/kdeldycke/click-extra/compare/v7.12.0...main)
 
 > [!WARNING]
 > This version is **not released yet** and is under active development.

--- a/citation.cff
+++ b/citation.cff
@@ -8,8 +8,8 @@ authors:
     email: kevin@deldycke.com
     orcid: "https://orcid.org/0000-0001-9748-9014"
 doi: 10.5281/zenodo.7116050
-version: 7.12.1.dev0
+version: 7.13.0.dev0
 # The release date is kept up to date by the external workflows. See:
 # https://github.com/kdeldycke/workflows/blob/33b704b489c1aa18b7b7efbf963e153e91e1c810/.github/workflows/changelog.yaml#L135-L137
-date-released: 2026-04-15
+date-released: 2026-04-16
 url: "https://github.com/kdeldycke/click-extra"

--- a/click_extra/__init__.py
+++ b/click_extra/__init__.py
@@ -263,7 +263,7 @@ __all__ = [
 """
 
 
-__version__ = "7.12.1.dev0"
+__version__ = "7.13.0.dev0"
 __git_branch__ = ""
 __git_date__ = ""
 __git_long_hash__ = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "uv-build>=0.9" ]
 [project]
 # Docs: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
 name = "click-extra"
-version = "7.12.1.dev0"
+version = "7.13.0.dev0"
 description = "🌈 Drop-in replacement for Click to make user-friendly and colorful CLI"
 readme = "readme.md"
 keywords = [
@@ -191,7 +191,7 @@ click-extra-demo = "click_extra.__main__:main"
 
 [project.urls]
 "Homepage" = "https://github.com/kdeldycke/click-extra"
-"Download" = "https://github.com/kdeldycke/click-extra/releases/tag/v7.12.1.dev0"
+"Download" = "https://github.com/kdeldycke/click-extra/releases/tag/v7.13.0.dev0"
 "Changelog" = "https://github.com/kdeldycke/click-extra/blob/main/changelog.md"
 "Issues" = "https://github.com/kdeldycke/click-extra/issues"
 "Repository" = "https://github.com/kdeldycke/click-extra"
@@ -363,7 +363,7 @@ run.source = [ "click_extra" ]
 report.precision = 2
 
 [tool.bumpversion]
-current_version = "7.12.1.dev0"
+current_version = "7.13.0.dev0"
 allow_dirty = true
 ignore_missing_files = true
 # Parse versions with an optional .devN suffix (PEP 440).

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/kdeldycke/click-extra/">
-    <img src="https://raw.githubusercontent.com/kdeldycke/click-extra/main/docs/assets/logo-banner.svg" alt="Click Extra">
+    <img src="https://raw.githubusercontent.com/kdeldycke/click-extra/v7.13.0.dev0/docs/assets/logo-banner.svg" alt="Click Extra">
   </a>
 </p>
 
@@ -44,11 +44,11 @@ This is a great way to play with Click Extra and check that it runs fine on your
 
 It transforms this vanilla `click` CLI:
 
-![click CLI help screen](https://raw.githubusercontent.com/kdeldycke/click-extra/main/docs/assets/click-help-screen.png)
+![click CLI help screen](https://raw.githubusercontent.com/kdeldycke/click-extra/v7.13.0.dev0/docs/assets/click-help-screen.png)
 
 Into this:
 
-![click-extra CLI help screen](https://raw.githubusercontent.com/kdeldycke/click-extra/main/docs/assets/click-extra-screen.png)
+![click-extra CLI help screen](https://raw.githubusercontent.com/kdeldycke/click-extra/v7.13.0.dev0/docs/assets/click-extra-screen.png)
 
 To undestrand how we ended up with the result above, [go read the tutorial](https://kdeldycke.github.io/click-extra/tutorial.html).
 

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-09T09:45:18.669791Z"
+exclude-newer = "2026-04-09T09:48:50.374979634Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -210,7 +210,7 @@ wheels = [
 
 [[package]]
 name = "click-extra"
-version = "7.12.1.dev0"
+version = "7.13.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "boltons" },
@@ -548,7 +548,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
### Description

Ready to be merged into `main` branch, at the discretion of the maintainers, to bump the minor part of the version number. Version bumps are scheduled daily and also triggered after releases. See the [`bump-version` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowschangelogyaml-jobs) for details.

### To bump version to `v7.13.0`

1. **Click `Ready for review`** button below, to get this PR out of `Draft` mode

2. **Click `Rebase and merge`** button below


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`cdada794`](https://github.com/kdeldycke/click-extra/commit/cdada79428c7ee9fc3493902d3b01fb3a8fb8375) |
| **Job** | [`bump-version`](https://github.com/kdeldycke/click-extra/blob/cdada79428c7ee9fc3493902d3b01fb3a8fb8375/.github/workflows/changelog.yaml) |
| **Workflow** | [`changelog.yaml`](https://github.com/kdeldycke/click-extra/blob/cdada79428c7ee9fc3493902d3b01fb3a8fb8375/.github/workflows/changelog.yaml) |
| **Run** | [#1132.1](https://github.com/kdeldycke/click-extra/actions/runs/24503594124) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.13.0`