### PR TITLE
Format Markdown

### DIFF
--- a/docs/colorize.md
+++ b/docs/colorize.md
@@ -378,7 +378,7 @@ Run `uvx click-extra render-matrix styles` in your terminal to see the real rend
 
 ## `click_extra.colorize` API
 
-````{eval-rst}
+```{eval-rst}
 .. autoclasstree:: click_extra.colorize
    :strict:
 
@@ -386,4 +386,4 @@ Run `uvx click-extra render-matrix styles` in your terminal to see the real rend
    :members:
    :undoc-members:
    :show-inheritance:
-````
+```

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -667,7 +667,7 @@ There is a miriad of possibilities. If you have some other examples in the same 
 
 ## `click_extra.commands` API
 
-````{eval-rst}
+```{eval-rst}
 .. autoclasstree:: click_extra.commands
    :strict:
 
@@ -675,4 +675,4 @@ There is a miriad of possibilities. If you have some other examples in the same 
    :members:
    :undoc-members:
    :show-inheritance:
-````
+```

--- a/docs/config.md
+++ b/docs/config.md
@@ -1699,7 +1699,7 @@ This works identically across all configuration formats (TOML, YAML, JSON, INI, 
 
 ## `click_extra.config` API
 
-````{eval-rst}
+```{eval-rst}
 .. autoclasstree:: click_extra.config
    :strict:
 
@@ -1707,4 +1707,4 @@ This works identically across all configuration formats (TOML, YAML, JSON, INI, 
    :members:
    :undoc-members:
    :show-inheritance:
-````
+```

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -37,7 +37,7 @@ When the requested value is below 1, it is clamped to 1 and a warning is logged.
 
 ## `click_extra.jobs` API
 
-````{eval-rst}
+```{eval-rst}
 .. autoclasstree:: click_extra.jobs
    :strict:
 
@@ -45,4 +45,4 @@ When the requested value is below 1, it is clamped to 1 and a warning is logged.
    :members:
    :undoc-members:
    :show-inheritance:
-````
+```

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -630,7 +630,7 @@ Click Extra has its own logger, named `click_extra`, which is used to print debu
 
 ## `click_extra.logging` API
 
-````{eval-rst}
+```{eval-rst}
 .. autoclasstree:: click_extra.logging
    :strict:
 
@@ -638,4 +638,4 @@ Click Extra has its own logger, named `click_extra`, which is used to print debu
    :members:
    :undoc-members:
    :show-inheritance:
-````
+```

--- a/docs/mkdocs.md
+++ b/docs/mkdocs.md
@@ -60,9 +60,9 @@ See the [full list of available ANSI lexer variants](pygments.md#lexer-variants)
 
 ## `click_extra.mkdocs` API
 
-````{eval-rst}
+```{eval-rst}
 .. automodule:: click_extra.mkdocs
    :members:
    :undoc-members:
    :show-inheritance:
-````
+```

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -138,7 +138,7 @@ Write example and tutorial.
 
 ## `click_extra.parameters` API
 
-````{eval-rst}
+```{eval-rst}
 .. autoclasstree:: click_extra.parameters
    :strict:
 
@@ -146,4 +146,4 @@ Write example and tutorial.
    :members:
    :undoc-members:
    :show-inheritance:
-````
+```

--- a/docs/pygments.md
+++ b/docs/pygments.md
@@ -376,7 +376,7 @@ The full set of color and style rendering demos is in [Colors and styles](colori
 
 ## `click_extra.pygments` API
 
-````{eval-rst}
+```{eval-rst}
 .. autoclasstree:: click_extra.pygments
    :strict:
 
@@ -384,4 +384,4 @@ The full set of color and style rendering demos is in [Colors and styles](colori
    :members:
    :undoc-members:
    :show-inheritance:
-````
+```

--- a/docs/pytest.md
+++ b/docs/pytest.md
@@ -22,7 +22,7 @@ Write example and tutorial.
 
 ## `click_extra.pytest` API
 
-````{eval-rst}
+```{eval-rst}
 .. autoclasstree:: click_extra.pytest
    :strict:
 
@@ -30,4 +30,4 @@ Write example and tutorial.
    :members:
    :undoc-members:
    :show-inheritance:
-````
+```

--- a/docs/sphinx.md
+++ b/docs/sphinx.md
@@ -982,7 +982,7 @@ NameError: name 'yo_cli' is not defined
 
 ## `click_extra.sphinx` API
 
-````{eval-rst}
+```{eval-rst}
 .. autoclasstree:: click_extra.sphinx
    :strict:
 
@@ -990,4 +990,4 @@ NameError: name 'yo_cli' is not defined
    :members:
    :undoc-members:
    :show-inheritance:
-````
+```

--- a/docs/table.md
+++ b/docs/table.md
@@ -566,7 +566,7 @@ assert result.stdout.index("Apple") < result.stdout.index("Cherry")
 
 ## `click_extra.table` API
 
-````{eval-rst}
+```{eval-rst}
 .. autoclasstree:: click_extra.table
    :strict:
 
@@ -574,4 +574,4 @@ assert result.stdout.index("Apple") < result.stdout.index("Cherry")
    :members:
    :undoc-members:
    :show-inheritance:
-````
+```

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -6,7 +6,7 @@ It does nothing else.
 
 ## `click_extra.telemetry` API
 
-````{eval-rst}
+```{eval-rst}
 .. autoclasstree:: click_extra.telemetry
    :strict:
 
@@ -14,4 +14,4 @@ It does nothing else.
    :members:
    :undoc-members:
    :show-inheritance:
-````
+```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,7 +6,7 @@ Write example and tutorial.
 
 ## `click_extra.testing` API
 
-````{eval-rst}
+```{eval-rst}
 .. autoclasstree:: click_extra.testing
    :strict:
 
@@ -14,4 +14,4 @@ Write example and tutorial.
    :members:
    :undoc-members:
    :show-inheritance:
-````
+```

--- a/docs/timer.md
+++ b/docs/timer.md
@@ -67,7 +67,7 @@ assert re.fullmatch(
 
 ## `click_extra.timer` API
 
-````{eval-rst}
+```{eval-rst}
 .. autoclasstree:: click_extra.timer
    :strict:
 
@@ -75,4 +75,4 @@ assert re.fullmatch(
    :members:
    :undoc-members:
    :show-inheritance:
-````
+```

--- a/docs/types.md
+++ b/docs/types.md
@@ -537,7 +537,7 @@ assert result.output == (
 
 ## `click_extra.types` API
 
-````{eval-rst}
+```{eval-rst}
 .. autoclasstree:: click_extra.types
    :strict:
 
@@ -545,4 +545,4 @@ assert result.output == (
    :members:
    :undoc-members:
    :show-inheritance:
-````
+```

--- a/docs/version.md
+++ b/docs/version.md
@@ -613,7 +613,7 @@ Other internal methods to build-up and render the version string are [available 
 
 ## `click_extra.version` API
 
-````{eval-rst}
+```{eval-rst}
 .. autoclasstree:: click_extra.version
    :strict:
 
@@ -621,4 +621,4 @@ Other internal methods to build-up and render the version string are [available 
    :members:
    :undoc-members:
    :show-inheritance:
-````
+```


### PR DESCRIPTION
### Description

Auto-formats Markdown files with [mdformat](https://github.com/hukkin/mdformat) and its plugins. See the [`format-markdown` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

> [!TIP]
> Customize Markdown formatting via [`[tool.mdformat]`](https://mdformat.readthedocs.io/en/stable/users/configuration_file.html) in your `pyproject.toml`, or via a native `.mdformat.toml` file.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`5cdd5086`](https://github.com/kdeldycke/click-extra/commit/5cdd50867f583bc4d8c01976a6c31c080905e89d) |
| **Job** | [`format-markdown`](https://github.com/kdeldycke/click-extra/blob/5cdd50867f583bc4d8c01976a6c31c080905e89d/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/5cdd50867f583bc4d8c01976a6c31c080905e89d/.github/workflows/autofix.yaml) |
| **Run** | [#2608.1](https://github.com/kdeldycke/click-extra/actions/runs/24503498462) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.13.0`