### PR TITLE
Format Python

### DIFF
--- a/click_extra/mkdocs.py
+++ b/click_extra/mkdocs.py
@@ -57,17 +57,13 @@ class AnsiColorPlugin(BasePlugin):
 
     def on_config(self, config: MkDocsConfig) -> MkDocsConfig:
         """Patch pymdownx.highlight formatters before page processing begins."""
-        if not issubclass(
-            pymdownx.highlight.BlockHtmlFormatter, AnsiHtmlFormatter
-        ):
+        if not issubclass(pymdownx.highlight.BlockHtmlFormatter, AnsiHtmlFormatter):
             pymdownx.highlight.BlockHtmlFormatter = type(
                 "AnsiBlockHtmlFormatter",
                 (AnsiHtmlFormatter, pymdownx.highlight.BlockHtmlFormatter),
                 {},
             )
-        if not issubclass(
-            pymdownx.highlight.InlineHtmlFormatter, AnsiHtmlFormatter
-        ):
+        if not issubclass(pymdownx.highlight.InlineHtmlFormatter, AnsiHtmlFormatter):
             pymdownx.highlight.InlineHtmlFormatter = type(
                 "AnsiInlineHtmlFormatter",
                 (AnsiHtmlFormatter, pymdownx.highlight.InlineHtmlFormatter),

--- a/tests/test_mkdocs.py
+++ b/tests/test_mkdocs.py
@@ -61,9 +61,7 @@ def test_on_config_patches_formatters():
 
     # Before patching: standard HtmlFormatter subclasses.
     assert not issubclass(pymdownx.highlight.BlockHtmlFormatter, AnsiHtmlFormatter)
-    assert not issubclass(
-        pymdownx.highlight.InlineHtmlFormatter, AnsiHtmlFormatter
-    )
+    assert not issubclass(pymdownx.highlight.InlineHtmlFormatter, AnsiHtmlFormatter)
 
     plugin = AnsiColorPlugin()
     plugin.on_config({})


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`96aede94`](https://github.com/kdeldycke/click-extra/commit/96aede947db69b7cc79c455e3301d297720ffa20) |
| **Job** | [`format-python`](https://github.com/kdeldycke/click-extra/blob/96aede947db69b7cc79c455e3301d297720ffa20/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/96aede947db69b7cc79c455e3301d297720ffa20/.github/workflows/autofix.yaml) |
| **Run** | [#2612.1](https://github.com/kdeldycke/click-extra/actions/runs/24503612740) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.13.0`