### PR TITLE
Sync `bump-my-version` config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -414,7 +414,6 @@ regex = true
 search = "date-released: \\d{{4}}-\\d{{2}}-\\d{{2}}"
 replace = "date-released: {utcnow:%Y-%m-%d}"
 
-# Pin image URLs to the release tag (only during release: dev0 → release).
 [[tool.bumpversion.files]]
 filename = "./readme.md"
 ignore_missing_version = true


### PR DESCRIPTION
### Description

Initializes the `[tool.bumpversion]` configuration in `pyproject.toml` from the [bundled template](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/bumpversion.toml). See the [`sync-bumpversion` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

### Configuration

Relevant [`[tool.repomatic]`](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#toolrepomatic-configuration) options:

```toml
[tool.repomatic]
bumpversion.sync = true
```


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`a2ccd28f`](https://github.com/kdeldycke/click-extra/commit/a2ccd28f1ae9ddcc8adee575e835a5954cb39eca) |
| **Job** | [`sync-bumpversion`](https://github.com/kdeldycke/click-extra/blob/a2ccd28f1ae9ddcc8adee575e835a5954cb39eca/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/a2ccd28f1ae9ddcc8adee575e835a5954cb39eca/.github/workflows/autofix.yaml) |
| **Run** | [#2620.1](https://github.com/kdeldycke/click-extra/actions/runs/24508762183) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.13.0`