### PR TITLE
Format Python

### DIFF
--- a/click_extra/mkdocs.py
+++ b/click_extra/mkdocs.py
@@ -71,7 +71,7 @@ def _patch_mkdocs_click() -> None:
     is idempotent: calling it twice has no additional effect.
     """
     try:
-        import mkdocs_click._docs as _docs
+        from mkdocs_click import _docs
     except ImportError:
         return
 

--- a/tests/test_mkdocs.py
+++ b/tests/test_mkdocs.py
@@ -45,7 +45,7 @@ def _clean_pymdownx():
 @pytest.fixture()
 def _clean_mkdocs_click():
     """Save and restore mkdocs-click functions around each test."""
-    import mkdocs_click._docs as _docs
+    from mkdocs_click import _docs
 
     orig_usage = _docs._make_usage
     orig_plain = _docs._make_plain_options
@@ -147,7 +147,7 @@ def _hello_cmd(name):
 @pytest.mark.usefixtures("_clean_mkdocs_click")
 def test_patch_mkdocs_click_usage():
     """After patching, ``_make_usage`` yields ``ansi-output`` fences."""
-    import mkdocs_click._docs as _docs
+    from mkdocs_click import _docs
 
     ctx = click.Context(_hello_cmd, info_name="hello")
     lines_before = list(_docs._make_usage(ctx))
@@ -164,7 +164,7 @@ def test_patch_mkdocs_click_usage():
 @pytest.mark.usefixtures("_clean_mkdocs_click")
 def test_patch_mkdocs_click_plain_options():
     """After patching, ``_make_plain_options`` yields ``ansi-output`` fences."""
-    import mkdocs_click._docs as _docs
+    from mkdocs_click import _docs
 
     ctx = click.Context(_hello_cmd, info_name="hello")
     lines_before = list(_docs._make_plain_options(ctx))
@@ -181,7 +181,7 @@ def test_patch_mkdocs_click_plain_options():
 @pytest.mark.usefixtures("_clean_mkdocs_click")
 def test_patch_mkdocs_click_idempotent():
     """Calling ``_patch_mkdocs_click`` twice does not double-wrap."""
-    import mkdocs_click._docs as _docs
+    from mkdocs_click import _docs
 
     _patch_mkdocs_click()
     usage_fn = _docs._make_usage
@@ -195,7 +195,7 @@ def test_patch_mkdocs_click_idempotent():
 @pytest.mark.usefixtures("_clean_pymdownx", "_clean_mkdocs_click")
 def test_on_config_patches_mkdocs_click():
     """``on_config`` patches mkdocs-click alongside pymdownx.highlight."""
-    import mkdocs_click._docs as _docs
+    from mkdocs_click import _docs
 
     assert not getattr(_docs, "_click_extra_patched", False)
 

--- a/tests/test_pygments.py
+++ b/tests/test_pygments.py
@@ -39,8 +39,6 @@ from click_extra import pygments as extra_pygments
 from click_extra.colorize import _nearest_256
 from click_extra.pygments import (
     _ANSI_STYLES,
-    _AnsiLinkEnd,
-    _AnsiLinkStart,
     _NAMED_COLORS,
     _PALETTE_256,
     _SGR_ATTR_ON,
@@ -51,6 +49,8 @@ from click_extra.pygments import (
     AnsiColorLexer,
     AnsiFilter,
     AnsiHtmlFormatter,
+    _AnsiLinkEnd,
+    _AnsiLinkStart,
     collect_session_lexers,
 )
 
@@ -686,9 +686,7 @@ def test_osc8_hyperlink(text, expected):
 
 def test_osc8_with_sgr():
     """OSC 8 hyperlink combined with SGR color preserves both."""
-    tokens = lex(
-        "\x1b[31m\x1b]8;;https://example.com\x07red link\x1b]8;;\x07\x1b[0m"
-    )
+    tokens = lex("\x1b[31m\x1b]8;;https://example.com\x07red link\x1b]8;;\x07\x1b[0m")
     assert tokens[0] == (_AnsiLinkStart, "https://example.com")
     assert tokens[1] == (Ansi.Red, "red link")
     assert tokens[2] == (_AnsiLinkEnd, "")
@@ -714,9 +712,7 @@ def test_osc8_unsafe_scheme_stripped(url):
 def test_osc8_implicit_close():
     """A new OSC 8 link implicitly closes the previous one."""
     tokens = lex(
-        "\x1b]8;;https://a.com\x07first"
-        "\x1b]8;;https://b.com\x07second"
-        "\x1b]8;;\x07"
+        "\x1b]8;;https://a.com\x07first\x1b]8;;https://b.com\x07second\x1b]8;;\x07"
     )
     assert tokens == [
         (_AnsiLinkStart, "https://a.com"),


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`9682de5a`](https://github.com/kdeldycke/click-extra/commit/9682de5a282aef80cdbd33baea7d4f12d78394e3) |
| **Job** | [`format-python`](https://github.com/kdeldycke/click-extra/blob/9682de5a282aef80cdbd33baea7d4f12d78394e3/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/9682de5a282aef80cdbd33baea7d4f12d78394e3/.github/workflows/autofix.yaml) |
| **Run** | [#2625.1](https://github.com/kdeldycke/click-extra/actions/runs/24515548384) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.13.0`