### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-09T10:55:44.008177369Z"
+exclude-newer = "2026-04-09T14:22:32.312367244Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -280,6 +280,7 @@ test = [
     { name = "coverage", extra = ["toml"] },
     { name = "extra-platforms", extra = ["pytest"] },
     { name = "mkdocs" },
+    { name = "mkdocs-click" },
     { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "myst-parser", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pymdown-extensions" },
@@ -348,6 +349,7 @@ test = [
     { name = "coverage", extras = ["toml"], specifier = ">=7.12" },
     { name = "extra-platforms", extras = ["pytest"], specifier = ">=5" },
     { name = "mkdocs", specifier = ">=1.4" },
+    { name = "mkdocs-click", specifier = ">=0.8" },
     { name = "myst-parser", specifier = ">=4" },
     { name = "pymdown-extensions", specifier = ">=10" },
     { name = "pytest", specifier = ">=9" },
@@ -842,6 +844,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-click"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "markdown" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/c7/8c25f3a3b379def41e6d0bb5c4beeab7aa8a394b17e749f498504102cfa5/mkdocs_click-0.9.0.tar.gz", hash = "sha256:6050917628d4740517541422b607404d044117bc31b770c4f9e9e1939a50c908", size = 18720, upload-time = "2025-04-07T16:59:36.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/fc/9124ab36e2341e78d8d9c669511bd70f52ea0de8105760c31fabec1f9396/mkdocs_click-0.9.0-py3-none-any.whl", hash = "sha256:5208e828f4f68f63c847c1ef7be48edee9964090390afc8f5b3d4cbe5ea9bbed", size = 15104, upload-time = "2025-04-07T16:59:34.807Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-04-09`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [mkdocs-click](https://pypi.org/project/mkdocs-click/) | (new) `0.9.0` | 2025-04-07 |

### Release notes

<details>
<summary><code>mkdocs-click</code></summary>

#### [`0.9.0`](https://github.com/mkdocs/mkdocs-click/releases/tag/0.9.0)

### Changed

- Drop support for Python 3.8. (Pull #​85)

### Added

- Add support for `click.Command`-like, `click.Group`-like and `click.Context`-like objects without requiring them to be actual subclasses. (Pull #​82)

### Fixed

- Remove explicit reference to `click.BaseCommand` and `click.MultiCommand` objects in anticipation of their deprecation. (Pull #​82)
- Properly ensure whitespace is trimmed from the usage string. (Pull #​83)
- Propagate `context_settings` to `click.Context`-like objects. (Pull #​79)
- Allow commands with no options. (Pull #​84)

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#toolrepomatic-configuration) options:

```toml
[tool.repomatic]
uv-lock.sync = true
```


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`9682de5a`](https://github.com/kdeldycke/click-extra/commit/9682de5a282aef80cdbd33baea7d4f12d78394e3) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/click-extra/blob/9682de5a282aef80cdbd33baea7d4f12d78394e3/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/9682de5a282aef80cdbd33baea7d4f12d78394e3/.github/workflows/autofix.yaml) |
| **Run** | [#2625.1](https://github.com/kdeldycke/click-extra/actions/runs/24515548384) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.13.0`