### PR TITLE
Format Markdown

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -641,16 +641,16 @@ Backing up /tmp
 
 Several dialects are supported:
 
-| Format                                 | Extensions        | Description                                                                               | Enabled by default |
-| :------------------------------------- | :---------------- | :---------------------------------------------------------------------------------------- | :----------------- |
-| [`TOML`](#toml)                        | `*.toml`          | -                                                                                         | ✅                 |
-| [`YAML`](#yaml)                        | `*.yaml`, `*.yml` | -                                                                                         | ❌                 |
-| [`JSON`](#json)                        | `*.json`          | -                                                                                         | ✅                 |
-| [`JSON5`](#json5)                      | `*.json5`         | A [superset of JSON made for configuration file](https://json5.org)                       | ❌                 |
-| [`JSONC`](#jsonc)                      | `*.jsonc`         | Like JSON, but with comments and trailing commas                                          | ❌                 |
-| [`HJSON`](#hjson)                      | `*.hjson`         | Another flavor of a [user-friendly JSON](https://hjson.github.io)                         | ❌                 |
-| [`INI`](#ini)                          | `*.ini`           | With extended interpolation, multi-level sections and non-native types (`list`, `set`, …) | ✅                 |
-| [`XML`](#xml)                          | `*.xml`           | -                                                                                         | ❌                 |
+| Format                              | Extensions        | Description                                                                               | Enabled by default |
+| :---------------------------------- | :---------------- | :---------------------------------------------------------------------------------------- | :----------------- |
+| [`TOML`](#toml)                     | `*.toml`          | -                                                                                         | ✅                 |
+| [`YAML`](#yaml)                     | `*.yaml`, `*.yml` | -                                                                                         | ❌                 |
+| [`JSON`](#json)                     | `*.json`          | -                                                                                         | ✅                 |
+| [`JSON5`](#json5)                   | `*.json5`         | A [superset of JSON made for configuration file](https://json5.org)                       | ❌                 |
+| [`JSONC`](#jsonc)                   | `*.jsonc`         | Like JSON, but with comments and trailing commas                                          | ❌                 |
+| [`HJSON`](#hjson)                   | `*.hjson`         | Another flavor of a [user-friendly JSON](https://hjson.github.io)                         | ❌                 |
+| [`INI`](#ini)                       | `*.ini`           | With extended interpolation, multi-level sections and non-native types (`list`, `set`, …) | ✅                 |
+| [`XML`](#xml)                       | `*.xml`           | -                                                                                         | ❌                 |
 | [`PYPROJECT_TOML`](#pyproject-toml) | `pyproject.toml`  | Reads `[tool.*]` sections from `pyproject.toml`                                           | ✅                 |
 
 Formats depending on third-party packages are not enabled by default. You need to [install Click Extra with the corresponding extra dependency group](install.md#extra-dependencies) to enable them.

--- a/docs/version.md
+++ b/docs/version.md
@@ -79,7 +79,7 @@ You can customize the message template with the following variables:
 | {py:attr}`{git_date} <click_extra.version.ExtraVersionOption.git_date>`               | The commit date of the current `HEAD` in ISO format (`YYYY-MM-DD HH:MM:SS +ZZZZ`), or `None` if not in a Git repository or Git is not available.                                       |
 | {py:attr}`{git_tag} <click_extra.version.ExtraVersionOption.git_tag>`                 | The Git tag pointing at `HEAD`, or `None` if `HEAD` is not at a tagged commit.                                                                                                         |
 | {py:attr}`{git_tag_sha} <click_extra.version.ExtraVersionOption.git_tag_sha>`         | The full commit SHA that the current tag points at, or `None` if `HEAD` is not at a tagged commit.                                                                                     |
-| {py:attr}`{prog_name} <click_extra.version.ExtraVersionOption.prog_name>`             | The display name of the program. Defaults to Click's `info_name`, but can be [overridden via `prog_name` on the command decorator](commands.md#version-fields).                                  |
+| {py:attr}`{prog_name} <click_extra.version.ExtraVersionOption.prog_name>`             | The display name of the program. Defaults to Click's `info_name`, but can be [overridden via `prog_name` on the command decorator](commands.md#version-fields).                        |
 | {py:attr}`{env_info} <click_extra.version.ExtraVersionOption.env_info>`               | The [environment information](https://boltons.readthedocs.io/en/latest/ecoutils.html#boltons.ecoutils.get_profile) in JSON.                                                            |
 
 ```{note}


### PR DESCRIPTION
### Description

Auto-formats Markdown files with [mdformat](https://github.com/hukkin/mdformat) and its plugins. See the [`format-markdown` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

> [!TIP]
> Customize Markdown formatting via [`[tool.mdformat]`](https://mdformat.readthedocs.io/en/stable/users/configuration_file.html) in your `pyproject.toml`, or via a native `.mdformat.toml` file.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`5d2760c2`](https://github.com/kdeldycke/click-extra/commit/5d2760c21d73e942e87dc92cc17a01e0c82eee08) |
| **Job** | [`format-markdown`](https://github.com/kdeldycke/click-extra/blob/5d2760c21d73e942e87dc92cc17a01e0c82eee08/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/5d2760c21d73e942e87dc92cc17a01e0c82eee08/.github/workflows/autofix.yaml) |
| **Run** | [#2632.1](https://github.com/kdeldycke/click-extra/actions/runs/24519410299) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.13.0`