### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-15T17:43:29.355214Z"
+exclude-newer = "2026-04-15T17:51:03.092139313Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
@@ -553,7 +553,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -921,11 +921,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.0"
+version = "26.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
 ]
 
 [[package]]
@@ -1280,14 +1280,14 @@ wheels = [
 
 [[package]]
 name = "sphinx-autodoc-typehints"
-version = "3.9.11"
+version = "3.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/e9/d29ae58dd12971d2cbb872884676a70d1a5e4719b4d82e197264cdf0431a/sphinx_autodoc_typehints-3.9.11.tar.gz", hash = "sha256:28516c916b41fa83271ee2ab9191b73807e4113d3bfb94222ac87d8d9795b6e7", size = 70261, upload-time = "2026-03-24T16:57:28.462Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/71/f9375ce1ef3548c3b1fe42ed0706d8a86a96f34cd04de0507eda05488a9b/sphinx_autodoc_typehints-3.10.1.tar.gz", hash = "sha256:2c750dcab949098eb46e17171abbdf3a19bd2581709efa091b4590da99e68346", size = 73190, upload-time = "2026-04-13T16:05:39.985Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/e3/ff212b51c16717681792eaf18691e6b5affbbb3d4290147c457fa9127372/sphinx_autodoc_typehints-3.9.11-py3-none-any.whl", hash = "sha256:b5cbc7a56a9338021ab7a4e6aa132aa7829fa2f8b64eca927faab64cd3971b80", size = 37279, upload-time = "2026-03-24T16:57:27.147Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f9/eddd31fa106c022645dbd238959844c9db820781fd513754ecadde1e90ef/sphinx_autodoc_typehints-3.10.1-py3-none-any.whl", hash = "sha256:0ac4ee9e1f264517b7e163cf7beabf5a3c55dbd6c6fe25c0b12f3707f3d3eb95", size = 38839, upload-time = "2026-04-13T16:05:38.511Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-04-15`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [packaging](https://pypi.org/project/packaging/) | [`26.0` → `26.1`](https://github.com/pypa/packaging/compare/26.0...26.1) | 2026-04-14 |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | [`3.9.11` → `3.10.1`](https://github.com/tox-dev/sphinx-autodoc-typehints/compare/3.9.11...3.10.1) | 2026-04-13 |

### Release notes

<details>
<summary><code>packaging</code></summary>

#### [`26.1`](https://github.com/pypa/packaging/releases/tag/26.1)

Features:

* ~~PEP 783: add handling for Emscripten wheel tags by @​hoodmane in https://redirect.github.com/pypa/packaging/pull/804~~ (old name used in implementation, will be fixed in next release)
* PEP 803: add handling for the `abi3.abi3t` free-threading tag by @​ngoldbaum in https://redirect.github.com/pypa/packaging/pull/1099
* PEP 723: add `packaging.dependency_groups` module, based on the `dependency-groups` package by @​sirosen in https://redirect.github.com/pypa/packaging/pull/1065
* Add the `packaging.direct_url` module by @​sbidoul in https://redirect.github.com/pypa/packaging/pull/944
* Add the `packaging.errors` module by @​henryiii in https://redirect.github.com/pypa/packaging/pull/1071
* Add `SpecifierSet.is_unsatisfiable` using ranges (new internals that will be expanded in future versions) by @​notatallshaw in https://redirect.github.com/pypa/packaging/pull/1119
* Add `create_compatible_tags_selector` to select compatible tags by @​sbidoul in https://redirect.github.com/pypa/packaging/pull/1110
* Add a `key` argument to `SpecifierSet.filter()` by @​frostming in https://redirect.github.com/pypa/packaging/pull/1068
* Support `&` and `|` for `Marker`'s by @​henryiii in https://redirect.github.com/pypa/packaging/pull/1146
* Normalize `Version.__replace__` and add `Version.from_parts` by @​henryiii in https://redirect.github.com/pypa/packaging/pull/1078
* Add an option to validate compressed tag set sort order in `parse_wheel_filename` by @​r266-tech in https://redirect.github.com/pypa/packaging/pull/1150

Behavior adaptations:

* Narrow exclusion of pre-releases for `<V.postN` to match spec by @​notatallshaw in https://redirect.github.com/pypa/packaging/pull/1140
* Narrow exclusion of post-releases for `>V` to match spec by @​notatallshaw in https://redirect.github.com/pypa/packaging/pull/1141

... [Full release notes](https://github.com/pypa/packaging/releases/tag/26.1)

</details>

<details>
<summary><code>sphinx-autodoc-typehints</code></summary>

#### [`3.10.0`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.10.0)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

## What's Changed
* 🔒 ci(workflows): add zizmor security auditing by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/672
* ✨ feat(resolver): auto-inject :vartype: for annotated instance vars by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/678
* 🐛 fix(intersphinx): skip union aliases in type mapping by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/679


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.9.11...3.10.0

#### [`3.10.1`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.10.1)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

## What's Changed
* 🐛 fix(resolver): surface hints for @​no_type_check targets by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/681


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.10.0...3.10.1

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#toolrepomatic-configuration) options:

```toml
[tool.repomatic]
uv-lock.sync = true
```


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`a8bea883`](https://github.com/kdeldycke/click-extra/commit/a8bea883695c260871719e349b64069714b7b5f9) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/click-extra/blob/a8bea883695c260871719e349b64069714b7b5f9/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/a8bea883695c260871719e349b64069714b7b5f9/.github/workflows/autofix.yaml) |
| **Run** | [#2637.1](https://github.com/kdeldycke/click-extra/actions/runs/24793524979) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.13.0`