### PR TITLE
Format Python

### DIFF
--- a/click_extra/cli.py
+++ b/click_extra/cli.py
@@ -24,7 +24,6 @@ import click
 import cloup
 
 from . import (
-    Choice,
     ClickException,
     Color,
     argument,
@@ -260,8 +259,9 @@ def demo_styles(ctx: click.Context) -> None:
     table: list[list[str]] = []
     for color_name in _ALL_COLORS:
         row = [style(color_name, fg=color_name)]
-        for prop in _ALL_STYLES:
-            row.append(style(color_name, fg=color_name, **{prop: True}))
+        row.extend(
+            style(color_name, fg=color_name, **{prop: True}) for prop in _ALL_STYLES
+        )
         table.append(row)
     _find_print_table(ctx)(table, headers=headers)
 

--- a/click_extra/colorize.py
+++ b/click_extra/colorize.py
@@ -450,7 +450,10 @@ class ExtraHelpColorsMixin:  # (Command)??
         # ``collect_keywords`` can be called on commands that don't inherit the
         # mixin (used by ``wrap.patch_click`` for third-party CLIs).
         ExtraHelpColorsMixin._collect_params(
-            command.get_params(ctx), ctx, kw, options,
+            command.get_params(ctx),
+            ctx,
+            kw,
+            options,
         )
 
         # Collect option names and choices from parent groups. Subcommand
@@ -464,7 +467,9 @@ class ExtraHelpColorsMixin:  # (Command)??
                     options.update(param.secondary_opts)
                     if isinstance(param.type, click.Choice):
                         ExtraHelpColorsMixin._collect_choice_keywords(
-                            param, parent_ctx, kw,
+                            param,
+                            parent_ctx,
+                            kw,
                         )
             parent_ctx = parent_ctx.parent
 

--- a/click_extra/wrap.py
+++ b/click_extra/wrap.py
@@ -155,9 +155,8 @@ def patch_click(
         return _original_get_help(self, ctx)
 
     def _patched_format_help(self, ctx, formatter):
-        if (
-            isinstance(formatter, HelpExtraFormatter)
-            and not isinstance(self, ExtraHelpColorsMixin)
+        if isinstance(formatter, HelpExtraFormatter) and not isinstance(
+            self, ExtraHelpColorsMixin
         ):
             logger.debug(
                 "Collecting keywords for %s (%s).",
@@ -166,9 +165,7 @@ def patch_click(
             )
             # collect_keywords() now works on any command: static methods are
             # class-qualified and extra_keywords uses getattr with defaults.
-            formatter.keywords = (
-                ExtraHelpColorsMixin.collect_keywords(self, ctx)
-            )
+            formatter.keywords = ExtraHelpColorsMixin.collect_keywords(self, ctx)
             formatter.excluded_keywords = (
                 ExtraHelpColorsMixin._collect_excluded_keywords(ctx)
             )
@@ -352,9 +349,7 @@ def _config_args_for_target(
 
     # Extract the [click-extra.run.<script>] section from the raw config.
     app_name = root_ctx.command.name or ""
-    target_section = (
-        full_conf.get(app_name, {}).get("run", {}).get(script, {})
-    )
+    target_section = full_conf.get(app_name, {}).get("run", {}).get(script, {})
     if not target_section or not isinstance(target_section, dict):
         return ()
 
@@ -428,9 +423,7 @@ def run(
 
     module_path, function_name = resolve_target(script)
 
-    help_theme = (
-        HelpExtraTheme.light() if theme == "light" else HelpExtraTheme.dark()
-    )
+    help_theme = HelpExtraTheme.light() if theme == "light" else HelpExtraTheme.dark()
     # Color setting is inherited from the parent group's context, where
     # ColorOption already processed --color/--no-color flags and environment
     # variables (NO_COLOR, CLICOLOR, etc.).

--- a/tests/test_wrap.py
+++ b/tests/test_wrap.py
@@ -32,56 +32,56 @@ from click_extra.wrap import (
 )
 
 GREET_SCRIPT = (
-    'import click\n'
-    '\n'
-    '@click.command()\n'
+    "import click\n"
+    "\n"
+    "@click.command()\n"
     '@click.option("--name", default="World", help="Name to greet.")\n'
-    'def hello(name):\n'
+    "def hello(name):\n"
     '    """Greet someone."""\n'
     '    click.echo(f"Hello, {name}")\n'
-    '\n'
+    "\n"
     'if __name__ == "__main__":\n'
-    '    hello()\n'
+    "    hello()\n"
 )
 """Plain ``@click.command()`` script: patched via decorator defaults."""
 
 CUSTOM_CLS_SCRIPT = (
-    'import click\n'
-    '\n'
-    'class RecipeGroup(click.Group):\n'
+    "import click\n"
+    "\n"
+    "class RecipeGroup(click.Group):\n"
     '    """Custom group like Flask\'s FlaskGroup."""\n'
-    '\n'
-    '@click.command(cls=RecipeGroup)\n'
-    'def kitchen():\n'
+    "\n"
+    "@click.command(cls=RecipeGroup)\n"
+    "def kitchen():\n"
     '    """Manage recipes and ingredients."""\n'
-    '\n'
-    '@kitchen.command()\n'
+    "\n"
+    "@kitchen.command()\n"
     '@click.option("--servings", default=4, help="Number of servings.")\n'
-    'def bake(servings):\n'
+    "def bake(servings):\n"
     '    """Bake a cake."""\n'
     '    click.echo(f"Baking for {servings}")\n'
-    '\n'
+    "\n"
     'if __name__ == "__main__":\n'
-    '    kitchen()\n'
+    "    kitchen()\n"
 )
 """Script with explicit ``cls=RecipeGroup``: patched via method patching."""
 
 MULTI_OPTION_SCRIPT = (
-    'import click\n'
-    '\n'
-    '@click.command()\n'
+    "import click\n"
+    "\n"
+    "@click.command()\n"
     '@click.option("--city", default="Paris", help="City name.")\n'
     '@click.option("--unit", default="celsius", help="Temperature unit.")\n'
     '@click.option("--verbose", is_flag=True, help="Show details.")\n'
-    'def weather(city, unit, verbose):\n'
+    "def weather(city, unit, verbose):\n"
     '    """Check the weather."""\n'
     '    msg = f"{city}: 22 {unit}"\n'
-    '    if verbose:\n'
+    "    if verbose:\n"
     '        msg += " (detailed)"\n'
-    '    click.echo(msg)\n'
-    '\n'
+    "    click.echo(msg)\n"
+    "\n"
     'if __name__ == "__main__":\n'
-    '    weather()\n'
+    "    weather()\n"
 )
 """Script with multiple options for config passthrough tests."""
 
@@ -164,10 +164,7 @@ def test_patched_command_no_extra_params():
     """Patched commands carry no default_extra_params."""
     cmd = ColorizedCommand(name="test", callback=lambda: None)
     option_names = {
-        opt
-        for p in cmd.params
-        if isinstance(p, click.Option)
-        for opt in p.opts
+        opt for p in cmd.params if isinstance(p, click.Option) for opt in p.opts
     }
     for forbidden in ("--config", "--verbose", "--verbosity", "--timer"):
         assert forbidden not in option_names
@@ -250,7 +247,11 @@ def test_run_self(runner, args, expected):
     ],
 )
 def test_run_invokes_target(
-    runner, script_fixture, target_args, expected_text, request,
+    runner,
+    script_fixture,
+    target_args,
+    expected_text,
+    request,
 ):
     """The run subcommand forwards arguments to the target CLI."""
     script = request.getfixturevalue(script_fixture)
@@ -340,7 +341,8 @@ def test_group_dispatches_to_run(runner, greet_script, args, expected):
 def test_group_options_work_with_run(runner, greet_script, group_opts):
     """Default ExtraGroup options are accepted alongside the run subcommand."""
     result = runner.invoke(
-        demo, [*group_opts, "run", greet_script, "--help"],
+        demo,
+        [*group_opts, "run", greet_script, "--help"],
     )
     assert result.exit_code == 0
     assert "Greet someone." in result.output
@@ -399,7 +401,8 @@ def test_config_target_string(runner, greet_script, create_config):
         f'[tool.click-extra.run."{greet_script}"]\nname = "Alice"\n',
     )
     result = runner.invoke(
-        demo, ["--config", str(conf), "run", greet_script],
+        demo,
+        ["--config", str(conf), "run", greet_script],
     )
     assert result.exit_code == 0
     assert "Hello, Alice" in result.output
@@ -412,7 +415,8 @@ def test_config_target_bool_true(runner, weather_script, create_config):
         f'[tool.click-extra.run."{weather_script}"]\nverbose = true\n',
     )
     result = runner.invoke(
-        demo, ["--config", str(conf), "run", weather_script],
+        demo,
+        ["--config", str(conf), "run", weather_script],
     )
     assert result.exit_code == 0
     assert "(detailed)" in result.output
@@ -425,7 +429,8 @@ def test_config_target_bool_false_is_noop(runner, weather_script, create_config)
         f'[tool.click-extra.run."{weather_script}"]\nverbose = false\n',
     )
     result = runner.invoke(
-        demo, ["--config", str(conf), "run", weather_script],
+        demo,
+        ["--config", str(conf), "run", weather_script],
     )
     assert result.exit_code == 0
     # verbose defaults to false anyway, so output has no "(detailed)".
@@ -441,7 +446,8 @@ def test_config_target_multiple_keys(runner, weather_script, create_config):
         f'unit = "fahrenheit"\n',
     )
     result = runner.invoke(
-        demo, ["--config", str(conf), "run", weather_script],
+        demo,
+        ["--config", str(conf), "run", weather_script],
     )
     assert result.exit_code == 0
     assert "Tokyo" in result.output
@@ -463,7 +469,9 @@ def test_config_target_cli_overrides(runner, greet_script, create_config):
 
 
 def test_config_target_wrong_section_ignored(
-    runner, greet_script, create_config,
+    runner,
+    greet_script,
+    create_config,
 ):
     """Config for a different script name has no effect."""
     conf = create_config(
@@ -471,7 +479,8 @@ def test_config_target_wrong_section_ignored(
         '[tool.click-extra.run.other-cli]\nname = "Alice"\n',
     )
     result = runner.invoke(
-        demo, ["--config", str(conf), "run", greet_script],
+        demo,
+        ["--config", str(conf), "run", greet_script],
     )
     assert result.exit_code == 0
     assert "Hello, World" in result.output
@@ -484,7 +493,8 @@ def test_config_target_empty_section(runner, greet_script, create_config):
         f'[tool.click-extra.run."{greet_script}"]\n',
     )
     result = runner.invoke(
-        demo, ["--config", str(conf), "run", greet_script],
+        demo,
+        ["--config", str(conf), "run", greet_script],
     )
     assert result.exit_code == 0
     assert "Hello, World" in result.output
@@ -493,7 +503,8 @@ def test_config_target_empty_section(runner, greet_script, create_config):
 def test_config_target_no_config(runner, greet_script):
     """No config file at all: target runs with its own defaults."""
     result = runner.invoke(
-        demo, ["--no-config", "run", greet_script],
+        demo,
+        ["--no-config", "run", greet_script],
     )
     assert result.exit_code == 0
     assert "Hello, World" in result.output
@@ -503,16 +514,14 @@ def test_config_target_invalid_option(runner, greet_script, create_config):
     """An invalid config key is caught by the target CLI."""
     conf = create_config(
         "pyproject.toml",
-        f'[tool.click-extra.run."{greet_script}"]\n'
-        f'nonexistent_option = "bad"\n',
+        f'[tool.click-extra.run."{greet_script}"]\nnonexistent_option = "bad"\n',
     )
     result = runner.invoke(
-        demo, ["--config", str(conf), "run", greet_script],
+        demo,
+        ["--config", str(conf), "run", greet_script],
     )
     assert result.exit_code != 0
     assert "No such option" in result.output
-
-
 
 
 # -- _config_args_for_target unit tests ----------------------------------------


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`c29479e3`](https://github.com/kdeldycke/click-extra/commit/c29479e315bc8a0797e0af5897e245cf90476314) |
| **Job** | [`format-python`](https://github.com/kdeldycke/click-extra/blob/c29479e315bc8a0797e0af5897e245cf90476314/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/c29479e315bc8a0797e0af5897e245cf90476314/.github/workflows/autofix.yaml) |
| **Run** | [#2649.1](https://github.com/kdeldycke/click-extra/actions/runs/24831925303) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.13.0`