### PR TITLE
Format Python

### DIFF
--- a/click_extra/cli.py
+++ b/click_extra/cli.py
@@ -129,9 +129,7 @@ def _walk_cmd_params(cmd, ctx, parent_keys=()):
             if subcmd is None:
                 continue
             subcmd_ctx = click.Context(subcmd, parent=ctx, info_name=subcmd_name)
-            yield from _walk_cmd_params(
-                subcmd, subcmd_ctx, (*parent_keys, subcmd_name)
-            )
+            yield from _walk_cmd_params(subcmd, subcmd_ctx, (*parent_keys, subcmd_name))
 
 
 @demo.command(
@@ -205,9 +203,7 @@ def show_params_cmd(
                 f"Specify the correct one with module:name notation."
             )
         else:
-            raise ClickException(
-                f"No Click commands found in {module_path}."
-            )
+            raise ClickException(f"No Click commands found in {module_path}.")
 
     # Navigate to subcommand if specified.
     assert isinstance(cli_obj, click.Command)

--- a/click_extra/parameters.py
+++ b/click_extra/parameters.py
@@ -456,7 +456,7 @@ def get_param_spec(param: click.Parameter, ctx: click.Context) -> str | None:
     """
     if not hasattr(param, "hidden"):
         return None
-    with (patch.object(param, "hidden", False) if param.hidden else nullcontext()):
+    with patch.object(param, "hidden", False) if param.hidden else nullcontext():
         help_record = param.get_help_record(ctx)
         return help_record[0] if help_record else None
 
@@ -483,9 +483,7 @@ def format_param_row(
 
     if is_structured:
         default_val = param.get_default(ctx)
-        if not isinstance(
-            default_val, (str, int, float, bool, list, type(None))
-        ):
+        if not isinstance(default_val, (str, int, float, bool, list, type(None))):
             default_val = repr(default_val)
         return (
             path,

--- a/click_extra/wrap.py
+++ b/click_extra/wrap.py
@@ -361,7 +361,9 @@ def _config_args_for_target(
     # TOML basic strings interpret backslashes as escape sequences, so users
     # must use forward slashes in their pyproject.toml keys.
     normalized_script = script.replace("\\", "/")
-    target_section = full_conf.get(app_name, {}).get("wrap", {}).get(normalized_script, {})
+    target_section = (
+        full_conf.get(app_name, {}).get("wrap", {}).get(normalized_script, {})
+    )
     if not target_section or not isinstance(target_section, dict):
         return ()
 


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`0df3d2a0`](https://github.com/kdeldycke/click-extra/commit/0df3d2a03300e8b347c5444405179d995b7de264) |
| **Job** | [`format-python`](https://github.com/kdeldycke/click-extra/blob/0df3d2a03300e8b347c5444405179d995b7de264/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/0df3d2a03300e8b347c5444405179d995b7de264/.github/workflows/autofix.yaml) |
| **Run** | [#2660.1](https://github.com/kdeldycke/click-extra/actions/runs/24890879828) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.13.0`