### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -580,7 +580,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -589,11 +589,11 @@ wheels = [
 
 [[package]]
 name = "extra-platforms"
-version = "11.0.5"
+version = "11.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f7/ab/757eb1e8b77757651dd0c69d18d118b22608be551dfc06e3f3962f6bb474/extra_platforms-11.0.5.tar.gz", hash = "sha256:89ae7971ba79193a256af16b44f3b9ab1c16dc4ba671f80e6110fa421679a82e", size = 68848, upload-time = "2026-04-03T09:46:30.122Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/7b/0049f8a7817ac4eb6ad1af72c7938fff3e2677d55468c87de792208e068c/extra_platforms-11.1.0.tar.gz", hash = "sha256:3045d722cab2b422a8fcbcba7f52026c33523cb147616d99fc50947f8e952375", size = 69265, upload-time = "2026-04-21T08:28:21.694Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/07/f1644d0288f5ce4ad8b6c888dd46bced2eae3480265f2253cefd7f694a68/extra_platforms-11.0.5-py3-none-any.whl", hash = "sha256:b081d5b1159af6462793517ad8073f85bd4c31aa398dfb8acb7f49ff54f8b7cc", size = 72395, upload-time = "2026-04-03T09:46:31.413Z" },
+    { url = "https://files.pythonhosted.org/packages/38/75/5985d4b10248cc03f5d0ef03026f3cc69a427baa77b6b07fe26a674bba1a/extra_platforms-11.1.0-py3-none-any.whl", hash = "sha256:5d4476774e5d639813060c239b40481a714f785515db66bcbb19a7b3881debc1", size = 72560, upload-time = "2026-04-21T08:28:20.216Z" },
 ]
 
 [package.optional-dependencies]
@@ -1088,14 +1088,14 @@ wheels = [
 
 [[package]]
 name = "pytest-randomly"
-version = "4.0.1"
+version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/1d/258a4bf1109258c00c35043f40433be5c16647387b6e7cd5582d638c116b/pytest_randomly-4.0.1.tar.gz", hash = "sha256:174e57bb12ac2c26f3578188490bd333f0e80620c3f47340158a86eca0593cd8", size = 14130, upload-time = "2025-09-12T15:23:00.085Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/b3/36192dacc0f470ac2cc516f73e01739c9a48a8224f76beada4f85e1c8a89/pytest_randomly-4.1.0.tar.gz", hash = "sha256:47f1d9746c3bc3efabd53ae1ebfb8bb385cf3d4df4b505b6d58d9c97a3dfe70f", size = 14302, upload-time = "2026-04-20T13:01:51.831Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/3e/a4a9227807b56869790aad3e24472a554b585974fe7e551ea350f50897ae/pytest_randomly-4.0.1-py3-none-any.whl", hash = "sha256:e0dfad2fd4f35e07beff1e47c17fbafcf98f9bf4531fd369d9260e2f858bfcb7", size = 8304, upload-time = "2025-09-12T15:22:58.946Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/db/2df9a1fca597a273f957a559c20c2d95d629928384507b2afa43ba6909d1/pytest_randomly-4.1.0-py3-none-any.whl", hash = "sha256:f55e89e53367b090c0c053697d7f9d77595543d0e0516c93978b50c0f6b252f9", size = 8353, upload-time = "2026-04-20T13:01:50.382Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `1-01-01`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | [`11.0.5` → `11.1.0`](https://github.com/kdeldycke/extra-platforms/compare/v11.0.5...v11.1.0) | 2026-04-21 |
| [pytest-randomly](https://pypi.org/project/pytest-randomly/) | [`4.0.1` → `4.1.0`](https://github.com/pytest-dev/pytest-randomly/compare/v4.0.1...v4.1.0) | 2026-04-20 |

### Release notes

<details>
<summary><code>extra-platforms</code></summary>

#### [`v11.1.0`](https://github.com/kdeldycke/extra-platforms/releases/tag/v11.1.0)

> [!NOTE]
> `11.1.0` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/11.1.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v11.1.0).

- Add NixOS platform detection.
- Convert Python docstrings to MyST markdown; render them with the `repomatic.myst_docstrings` Sphinx extension.
- Expand CI test matrix to cover Ubuntu 22.04, Ubuntu 22.04 ARM, macOS 14, macOS 15, and Windows 2022.

**Full changelog**: [`v11.0.5...v11.1.0`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v11.0.5...v11.1.0)

</details>

<details>
<summary><code>pytest-randomly</code></summary>

[Changelog](https://redirect.github.com/pytest-dev/pytest-randomly/blob/main/CHANGELOG.rst)

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#toolrepomatic-configuration) options:

```toml
[tool.repomatic]
uv-lock.sync = true
```


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`e30315e7`](https://github.com/kdeldycke/click-extra/commit/e30315e75c622f78611e6578e33bcb9499bdac25) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/click-extra/blob/e30315e75c622f78611e6578e33bcb9499bdac25/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/e30315e75c622f78611e6578e33bcb9499bdac25/.github/workflows/autofix.yaml) |
| **Run** | [#2678.1](https://github.com/kdeldycke/click-extra/actions/runs/25053983252) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.14.0`