### PR TITLE
Bump minor version to `v7.15.0`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [`7.14.2.dev0` (unreleased)](https://github.com/kdeldycke/click-extra/compare/v7.14.1...main)
+## [`7.15.0.dev0` (unreleased)](https://github.com/kdeldycke/click-extra/compare/v7.14.1...main)
 
 > [!WARNING]
 > This version is **not released yet** and is under active development.

--- a/citation.cff
+++ b/citation.cff
@@ -8,8 +8,8 @@ authors:
     email: kevin@deldycke.com
     orcid: "https://orcid.org/0000-0001-9748-9014"
 doi: 10.5281/zenodo.7116050
-version: 7.14.2.dev0
+version: 7.15.0.dev0
 # The release date is kept up to date by the external workflows. See:
 # https://github.com/kdeldycke/workflows/blob/33b704b489c1aa18b7b7efbf963e153e91e1c810/.github/workflows/changelog.yaml#L135-L137
-date-released: 2026-04-26
+date-released: 2026-04-28
 url: "https://github.com/kdeldycke/click-extra"

--- a/click_extra/__init__.py
+++ b/click_extra/__init__.py
@@ -267,7 +267,7 @@ __all__ = [
 """
 
 
-__version__ = "7.14.2.dev0"
+__version__ = "7.15.0.dev0"
 __git_branch__ = ""
 __git_date__ = ""
 __git_long_hash__ = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "uv-build>=0.9" ]
 [project]
 # Docs: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
 name = "click-extra"
-version = "7.14.2.dev0"
+version = "7.15.0.dev0"
 description = "🌈 Drop-in replacement for Click to make user-friendly and colorful CLI"
 readme = "readme.md"
 keywords = [
@@ -189,7 +189,7 @@ click-extra = "click_extra.__main__:main"
 
 [project.urls]
 "Homepage" = "https://github.com/kdeldycke/click-extra"
-"Download" = "https://github.com/kdeldycke/click-extra/releases/tag/v7.14.2.dev0"
+"Download" = "https://github.com/kdeldycke/click-extra/releases/tag/v7.15.0.dev0"
 "Changelog" = "https://github.com/kdeldycke/click-extra/blob/main/changelog.md"
 "Issues" = "https://github.com/kdeldycke/click-extra/issues"
 "Repository" = "https://github.com/kdeldycke/click-extra"
@@ -379,7 +379,7 @@ run.source = [ "click_extra" ]
 report.precision = 2
 
 [tool.bumpversion]
-current_version = "7.14.2.dev0"
+current_version = "7.15.0.dev0"
 allow_dirty = true
 ignore_missing_files = true
 # Parse versions with an optional .devN suffix (PEP 440).

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-19T16:52:09.725697203Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
@@ -222,7 +222,7 @@ wheels = [
 
 [[package]]
 name = "click-extra"
-version = "7.14.2.dev0"
+version = "7.15.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "boltons" },
@@ -328,7 +328,7 @@ typing = [
 [package.metadata]
 requires-dist = [
     { name = "boltons", specifier = ">=20" },
-    { name = "click", specifier = ">=8.1" },
+    { name = "click", specifier = ">=8.3.1" },
     { name = "cloup", specifier = ">=3.0.7" },
     { name = "deepmerge", specifier = ">=1.0.1" },
     { name = "docutils", marker = "extra == 'sphinx'", specifier = ">=0.20" },


### PR DESCRIPTION
### Description

Ready to be merged into `main` branch, at the discretion of the maintainers, to bump the minor part of the version number. Version bumps are scheduled daily and also triggered after releases. See the [`bump-version` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowschangelogyaml-jobs) for details.

### To bump version to `v7.15.0`

1. **Click `Ready for review`** button below, to get this PR out of `Draft` mode

2. **Click `Rebase and merge`** button below


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`d9f06c1b`](https://github.com/kdeldycke/click-extra/commit/d9f06c1b75946731f65c0a17d0b55744bbf289f9) |
| **Job** | [`bump-version`](https://github.com/kdeldycke/click-extra/blob/d9f06c1b75946731f65c0a17d0b55744bbf289f9/.github/workflows/changelog.yaml) |
| **Workflow** | [`changelog.yaml`](https://github.com/kdeldycke/click-extra/blob/d9f06c1b75946731f65c0a17d0b55744bbf289f9/.github/workflows/changelog.yaml) |
| **Run** | [#1180.1](https://github.com/kdeldycke/click-extra/actions/runs/25043621842) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.14.0`