### PR TITLE
Format Python

### DIFF
--- a/docs/pygments.md
+++ b/docs/pygments.md
@@ -255,12 +255,14 @@ for orig_lexer, ansi_lexer in sorted(
         ", ".join(f"`{a}`" for a in sorted(ansi_lexer.aliases)),
     ])
 
-print(render_table(
-    rows,
-    table_format=TableFormat.GITHUB,
-    headers=["Original Lexer", "Original IDs", "ANSI variants"],
-    colalign=["left", "left", "left"],
-))
+print(
+    render_table(
+        rows,
+        table_format=TableFormat.GITHUB,
+        headers=["Original Lexer", "Original IDs", "ANSI variants"],
+        colalign=["left", "left", "left"],
+    )
+)
 ```
 
 ### Lexers usage

--- a/tests/sphinx/test_sphinx_python.py
+++ b/tests/sphinx/test_sphinx_python.py
@@ -222,9 +222,7 @@ def test_exec_directives_disabled_by_default(tmp_path):
     """)
     html = app.build_document(content)
     assert html is not None
-    assert sentinel not in html, (
-        "directive executed despite the opt-in gate being off"
-    )
+    assert sentinel not in html, "directive executed despite the opt-in gate being off"
 
 
 def test_exec_directives_enabled_with_opt_in(tmp_path):


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`e30315e7`](https://github.com/kdeldycke/click-extra/commit/e30315e75c622f78611e6578e33bcb9499bdac25) |
| **Job** | [`format-python`](https://github.com/kdeldycke/click-extra/blob/e30315e75c622f78611e6578e33bcb9499bdac25/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/e30315e75c622f78611e6578e33bcb9499bdac25/.github/workflows/autofix.yaml) |
| **Run** | [#2678.1](https://github.com/kdeldycke/click-extra/actions/runs/25053983252) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.14.0`