### PR TITLE
Format Python

### DIFF
--- a/click_extra/__init__.py
+++ b/click_extra/__init__.py
@@ -44,7 +44,6 @@ from .commands import (
     HelpCommand,
     LazyGroup,
 )
-from .context import ExtraContext
 from .config import (
     DEFAULT_SUBCOMMANDS_KEY,
     NO_CONFIG,
@@ -58,6 +57,7 @@ from .config import (
     get_tool_config,
     normalize_config_keys,
 )
+from .context import ExtraContext
 from .decorators import (  # type: ignore[no-redef]
     argument,
     color_option,

--- a/click_extra/commands.py
+++ b/click_extra/commands.py
@@ -33,10 +33,8 @@ from . import context
 from .colorize import (
     ColorOption,
     ExtraHelpColorsMixin,
-    HelpExtraFormatter,
     HelpKeywords,
 )
-from .context import ExtraContext
 from .config import (
     DEFAULT_SUBCOMMANDS_KEY,
     PREPEND_SUBCOMMANDS_KEY,
@@ -45,6 +43,7 @@ from .config import (
     ValidateConfigOption,
     _make_schema_callable,
 )
+from .context import ExtraContext
 from .envvar import clean_envvar_id, param_envvar_ids
 from .logging import VerboseOption, VerbosityOption
 from .parameters import ExtraOption, ShowParamsOption

--- a/click_extra/config.py
+++ b/click_extra/config.py
@@ -72,11 +72,11 @@ from . import (
     UNPROCESSED,
     ParameterSource,
     Path as ClickPath,
+    context,
     echo,
     get_app_dir,
     get_current_context,
 )
-from . import context
 from .parameters import ExtraOption, ParamStructure, search_params
 
 if sys.version_info >= (3, 11):

--- a/click_extra/context.py
+++ b/click_extra/context.py
@@ -33,6 +33,7 @@ and read the entries you need:
 
     from click_extra import command, context, echo, pass_context
 
+
     @command
     @pass_context
     def cli(ctx):
@@ -272,7 +273,7 @@ def get(ctx: click.Context, key: str, default: Any = None) -> Any:
     return ctx.meta.get(key, default)
 
 
-def set(  # noqa: A001
+def set(
     ctx: click.Context,
     key: str,
     value: Any,

--- a/click_extra/logging.py
+++ b/click_extra/logging.py
@@ -37,8 +37,7 @@ from unittest.mock import patch
 import click
 from click.types import IntRange
 
-from . import EnumChoice
-from . import context
+from . import EnumChoice, context
 from .parameters import ExtraOption, search_params
 from .theme import get_current_theme
 

--- a/click_extra/parameters.py
+++ b/click_extra/parameters.py
@@ -29,8 +29,7 @@ import click
 import cloup
 from deepmerge import always_merger
 
-from . import UNSET, EnumChoice, ParamType, Style, get_current_context
-from . import context
+from . import UNSET, EnumChoice, ParamType, Style, context, get_current_context
 from .envvar import param_envvar_ids
 
 TYPE_CHECKING = False

--- a/click_extra/table.py
+++ b/click_extra/table.py
@@ -30,8 +30,7 @@ import tabulate
 from boltons.strutils import strip_ansi
 from tabulate import DataRow, TableFormat as TabulateTableFormat
 
-from . import EnumChoice, echo, style
-from . import context
+from . import EnumChoice, context, echo, style
 from .parameters import ExtraOption
 
 TYPE_CHECKING = False

--- a/click_extra/theme.py
+++ b/click_extra/theme.py
@@ -43,8 +43,7 @@ import cloup
 from cloup._util import identity
 from cloup.styling import Color
 
-from . import Style
-from . import context
+from . import Style, context
 from .parameters import ExtraOption
 
 TYPE_CHECKING = False

--- a/click_extra/timer.py
+++ b/click_extra/timer.py
@@ -20,8 +20,7 @@ from __future__ import annotations
 from gettext import gettext as _
 from time import perf_counter
 
-from . import echo
-from . import context
+from . import context, echo
 from .parameters import ExtraOption
 
 TYPE_CHECKING = False

--- a/click_extra/wrap.py
+++ b/click_extra/wrap.py
@@ -34,8 +34,7 @@ import click
 import cloup
 from click.utils import make_str
 
-from . import context
-from . import theme as _theme
+from . import context, theme as _theme
 from .colorize import ExtraHelpColorsMixin, HelpExtraFormatter
 from .commands import ColorizedCommand, ColorizedGroup, ExtraGroup
 from .context import ExtraContext

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -18,8 +18,7 @@ from __future__ import annotations
 
 from click.testing import CliRunner
 
-from click_extra import command, context, echo, option
-from click_extra import theme as _theme
+from click_extra import command, context, echo, option, theme as _theme
 
 
 @command


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`c99cecee`](https://github.com/kdeldycke/click-extra/commit/c99cecee63afda562a83c2f06782dd8ce3158215) |
| **Job** | [`format-python`](https://github.com/kdeldycke/click-extra/blob/c99cecee63afda562a83c2f06782dd8ce3158215/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/c99cecee63afda562a83c2f06782dd8ce3158215/.github/workflows/autofix.yaml) |
| **Run** | [#2698.1](https://github.com/kdeldycke/click-extra/actions/runs/25280966299) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.16.0`