### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -577,7 +577,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -586,11 +586,11 @@ wheels = [
 
 [[package]]
 name = "extra-platforms"
-version = "11.1.0"
+version = "12.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7c/7b/0049f8a7817ac4eb6ad1af72c7938fff3e2677d55468c87de792208e068c/extra_platforms-11.1.0.tar.gz", hash = "sha256:3045d722cab2b422a8fcbcba7f52026c33523cb147616d99fc50947f8e952375", size = 69265, upload-time = "2026-04-21T08:28:21.694Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/56/068be906510dae5dec901a46efa0dcf2aee7f5640af0f0ea770f8c9710ca/extra_platforms-12.0.0.tar.gz", hash = "sha256:bfa32f5b17e810f6f97e35045db4245e6c9c45c87a9f27101f44d795e46042da", size = 72090, upload-time = "2026-04-24T12:49:18.843Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/75/5985d4b10248cc03f5d0ef03026f3cc69a427baa77b6b07fe26a674bba1a/extra_platforms-11.1.0-py3-none-any.whl", hash = "sha256:5d4476774e5d639813060c239b40481a714f785515db66bcbb19a7b3881debc1", size = 72560, upload-time = "2026-04-21T08:28:20.216Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/4f/8e3562108157fe9bc6160a73019532bb57090e4194a07d6f3ac6ef2d10ba/extra_platforms-12.0.0-py3-none-any.whl", hash = "sha256:5f6d0abad22cc3bea0f32bf8aa62a6a106e38203bb4c7c19989e56a61b542b52", size = 75347, upload-time = "2026-04-24T12:49:19.94Z" },
 ]
 
 [package.optional-dependencies]
@@ -971,11 +971,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.1"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-04-26`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | [`11.1.0` → `12.0.0`](https://github.com/kdeldycke/extra-platforms/compare/v11.1.0...v12.0.0) | 2026-04-24 |
| [packaging](https://pypi.org/project/packaging/) | [`26.1` → `26.2`](https://github.com/pypa/packaging/compare/26.1...26.2) | 2026-04-24 |

### Release notes

<details>
<summary><code>extra-platforms</code></summary>

#### [`v12.0.0`](https://github.com/kdeldycke/extra-platforms/releases/tag/v12.0.0)

> [!NOTE]
> `12.0.0` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/12.0.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v12.0.0).

- Add `SH` (Bourne Shell) trait and `is_sh()` detection function.
- Add `GUIX_BUILD` CI trait and `is_guix_build()` detection function.
- Add `--json`, `--version`, and `--help` options to the CLI. `--json` outputs all detected traits and groups as a JSON object for scripting.
- Overhaul shell detection: resolve symlinks in `SHELL` before identifying the implementation (so `/bin/sh` → `/bin/bash` detects bash, not sh); `current_shell()` now disambiguates via three-tier priority — startup env vars, then `/proc` parent process tree, then `SHELL` value — fixing detection on CI runners where `SHELL=/bin/sh` points to a different shell than the one actually executing; `SH` is treated as a low-specificity fallback and stripped when a more specific shell is detected; new `version_env_var` field on `Shell` records each shell's startup environment variable (like `BASH_VERSION` for Bash); `is_powershell()` now checks `PSModulePath` as a presence signal rather than a version variable. Use `is_bourne_shells()` to check for a Bourne-compatible interface regardless of implementation.

**Full changelog**: [`v11.1.0...v12.0.0`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v11.1.0...v12.0.0)

</details>

<details>
<summary><code>packaging</code></summary>

#### [`26.2`](https://github.com/pypa/packaging/releases/tag/26.2)

## What's Changed

Fixes:

* Fix incorrect sysconfig var name for pyemscripten by @​ryanking13 in https://redirect.github.com/pypa/packaging/pull/1160
* Make `Version`, `Specifier`, `SpecifierSet`, `Tag`, `Marker`, and `Requirement` pickle-safe
  and backward-compatible with pickles created in 25.0-26.1 (including references to the removed
  ``packaging._structures`` module) by @​eachimei and @​henryiii in https://redirect.github.com/pypa/packaging/pull/1163, https://redirect.github.com/pypa/packaging/pull/1168, https://redirect.github.com/pypa/packaging/pull/1170, and https://redirect.github.com/pypa/packaging/pull/1171
* fix: re-export ExceptionGroup for now by @​henryiii in https://redirect.github.com/pypa/packaging/pull/1164

Documentation:

* docs: add errors section and fix missing details by @​henryiii in https://redirect.github.com/pypa/packaging/pull/1159
* docs(dev): document property-based test suite by @​r266-tech in https://redirect.github.com/pypa/packaging/pull/1167
* Fix typo in DirectUrl documentation by @​sbidoul in https://redirect.github.com/pypa/packaging/pull/1169
* docs(specifiers): add is_unsatisfiable() usage example by @​r266-tech in https://redirect.github.com/pypa/packaging/pull/1166

Internal:

* Enable the auditor persona on zizmor by @​henryiii in https://redirect.github.com/pypa/packaging/pull/1158
* Test new pickle guarantees by @​henryiii in https://redirect.github.com/pypa/packaging/pull/1174
* Use native uv integration in rtd by @​henryiii in https://redirect.github.com/pypa/packaging/pull/1175



## New Contributors
* @​ryanking13 made their first contribution in https://redirect.github.com/pypa/packaging/pull/1160
* @​eachimei made their first contribution in https://redirect.github.com/pypa/packaging/pull/1163

**Full Changelog**: https://redirect.github.com/pypa/packaging/compare/26.1...26.2

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`c99cecee`](https://github.com/kdeldycke/click-extra/commit/c99cecee63afda562a83c2f06782dd8ce3158215) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/click-extra/blob/c99cecee63afda562a83c2f06782dd8ce3158215/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/c99cecee63afda562a83c2f06782dd8ce3158215/.github/workflows/autofix.yaml) |
| **Run** | [#2698.1](https://github.com/kdeldycke/click-extra/actions/runs/25280966299) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.16.0`