### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -577,7 +577,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -586,11 +586,11 @@ wheels = [
 
 [[package]]
 name = "extra-platforms"
-version = "12.0.0"
+version = "12.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/56/068be906510dae5dec901a46efa0dcf2aee7f5640af0f0ea770f8c9710ca/extra_platforms-12.0.0.tar.gz", hash = "sha256:bfa32f5b17e810f6f97e35045db4245e6c9c45c87a9f27101f44d795e46042da", size = 72090, upload-time = "2026-04-24T12:49:18.843Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/3e/b7dfcbd8ccfb8127f2b907e3c7eabf0ff34bebdc7ae126266fbb7eba7208/extra_platforms-12.0.1.tar.gz", hash = "sha256:55146246c1e4babe385d2438c4da54e3f0078cedc70914288bedbe6502849218", size = 72199, upload-time = "2026-04-26T21:06:51.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/4f/8e3562108157fe9bc6160a73019532bb57090e4194a07d6f3ac6ef2d10ba/extra_platforms-12.0.0-py3-none-any.whl", hash = "sha256:5f6d0abad22cc3bea0f32bf8aa62a6a106e38203bb4c7c19989e56a61b542b52", size = 75347, upload-time = "2026-04-24T12:49:19.94Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/dc/b61a087ba06eb0a53ebf8d3d51b901e84993a6e0138537d3239f15a82f3c/extra_platforms-12.0.1-py3-none-any.whl", hash = "sha256:e5df76a229c518fe5d12a049d6e54457b2f64bd1c440b185c60256f816b4d747", size = 75447, upload-time = "2026-04-26T21:06:49.757Z" },
 ]
 
 [package.optional-dependencies]
@@ -980,11 +980,11 @@ wheels = [
 
 [[package]]
 name = "pathspec"
-version = "1.1.0"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2e/17/9c3094b822982b9f1ea666d8580ce59000f61f87c1663556fb72031ad9ec/pathspec-1.1.0.tar.gz", hash = "sha256:f5d7c555da02fd8dde3e4a2354b6aba817a89112fa8f333f7917a2a4834dd080", size = 133918, upload-time = "2026-04-23T01:46:22.298Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/c9/8eed0486f074e9f1ca7f8ce5ad663e65f12fdab344028d658fa1b03d35e0/pathspec-1.1.0-py3-none-any.whl", hash = "sha256:574b128f7456bd899045ccd142dd446af7e6cfd0072d63ad73fbc55fbb4aaa42", size = 56264, upload-time = "2026-04-23T01:46:20.606Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-04-27`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | [`12.0.0` → `12.0.1`](https://github.com/kdeldycke/extra-platforms/compare/v12.0.0...v12.0.1) | 2026-04-26 |
| [pathspec](https://pypi.org/project/pathspec/) | [`1.1.0` → `1.1.1`](https://github.com/cpburnz/python-pathspec/compare/v1.1.0...v1.1.1) | 2026-04-27 |

### Release notes

<details>
<summary><code>extra-platforms</code></summary>

#### [`v12.0.1`](https://github.com/kdeldycke/extra-platforms/releases/tag/v12.0.1)

> [!NOTE]
> `12.0.1` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/12.0.1/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v12.0.1).

- Defer `logging` and `warnings` imports out of the cold-load path: the stdlib `logging` import pulls in `traceback` (and `_colorize` on Python 3.14+), which dominates import time on slow architectures like i586. Closes {issue}`494`
- Loosen the `test_import_time` threshold from 500 ms to 1000 ms as a safety margin for slower architectures.

**Full changelog**: [`v12.0.0...v12.0.1`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v12.0.0...v12.0.1)

</details>

<details>
<summary><code>pathspec</code></summary>

#### [`v1.1.1`](https://github.com/cpburnz/python-pathspec/releases/tag/v1.1.1)

Release v1.1.1. See [CHANGES.rst](https://redirect.github.com/cpburnz/python-pathspec/blob/v1.1.1/CHANGES.rst).

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`df372387`](https://github.com/kdeldycke/click-extra/commit/df372387a61cb511afb3d792726ef03617560164) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/click-extra/blob/df372387a61cb511afb3d792726ef03617560164/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/df372387a61cb511afb3d792726ef03617560164/.github/workflows/autofix.yaml) |
| **Run** | [#2706.1](https://github.com/kdeldycke/click-extra/actions/runs/25342119445) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.16.0`