### PR TITLE
Format Python

### DIFF
--- a/click_extra/config.py
+++ b/click_extra/config.py
@@ -1651,9 +1651,7 @@ class ConfigOption(ExtraOption, ParamStructure):
             return
         app_name = ctx.find_root().command.name or ctx.info_name or ""
         app_section = self._resolve_app_section(user_conf, app_name)
-        context.set(
-            ctx, context.TOOL_CONFIG, self._config_schema_callable(app_section)
-        )
+        context.set(ctx, context.TOOL_CONFIG, self._config_schema_callable(app_section))
 
     def merge_default_map(self, ctx: click.Context, user_conf: dict) -> None:
         """Save the user configuration into the context's ``default_map``.

--- a/click_extra/sphinx/click.py
+++ b/click_extra/sphinx/click.py
@@ -387,10 +387,7 @@ class ClickDirective(SphinxDirective):
             if option_id == "emphasize-lines":
                 if target == "source" and "emphasize-lines" in self.options:
                     options.append(f":emphasize-lines: {self.options[option_id]}")
-                elif (
-                    target == "results"
-                    and "emphasize-result-lines" in self.options
-                ):
+                elif target == "results" and "emphasize-result-lines" in self.options:
                     options.append(
                         f":emphasize-lines: {self.options['emphasize-result-lines']}"
                     )

--- a/tests/sphinx/test_sphinx_python.py
+++ b/tests/sphinx/test_sphinx_python.py
@@ -94,9 +94,9 @@ def test_python_run_emphasize_lines_split(sphinx_app_myst):
     # Result block carries the result emphasis on line 2 (the literal `second line`).
     assert '<span class="hll">second line\n</span>' in html
     # And the sibling lines are not highlighted.
-    assert (
-        '<span class="hll">first line\n</span>' not in html
-    ), "result emphasis must not bleed onto line 1 of the result block"
+    assert '<span class="hll">first line\n</span>' not in html, (
+        "result emphasis must not bleed onto line 1 of the result block"
+    )
 
 
 def test_python_render_passes_block_level_html(sphinx_app_myst):


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`eca6249f`](https://github.com/kdeldycke/click-extra/commit/eca6249f103b701389009757657adbe5e1325aa4) |
| **Job** | [`format-python`](https://github.com/kdeldycke/click-extra/blob/eca6249f103b701389009757657adbe5e1325aa4/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/eca6249f103b701389009757657adbe5e1325aa4/.github/workflows/autofix.yaml) |
| **Run** | [#2707.1](https://github.com/kdeldycke/click-extra/actions/runs/25490557122) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.16.0`