### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -577,7 +577,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1586,14 +1586,14 @@ wheels = [
 
 [[package]]
 name = "types-requests"
-version = "2.33.0.20260408"
+version = "2.33.0.20260503"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/6a/749dc53a54a3f35842c1f8197b3ca6b54af6d7458a1bfc75f6629b6da666/types_requests-2.33.0.20260408.tar.gz", hash = "sha256:95b9a86376807a216b2fb412b47617b202091c3ea7c078f47cc358d5528ccb7b", size = 23882, upload-time = "2026-04-08T04:34:49.33Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/b8/57e94268c0d82ac3eaa2fc35aa8ca7bbc2542f726b67dcf90b0b00a3b14d/types_requests-2.33.0.20260503.tar.gz", hash = "sha256:9721b2d9dbee7131f2fb39f20f0ebb1999c18cef4b512c9a7932f3722de7c5f4", size = 23931, upload-time = "2026-05-03T05:20:08.882Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/b8/78fd6c037de4788c040fdd323b3369804400351b7827473920f6c1d03c10/types_requests-2.33.0.20260408-py3-none-any.whl", hash = "sha256:81f31d5ea4acb39f03be7bc8bed569ba6d5a9c5d97e89f45ac43d819b68ca50f", size = 20739, upload-time = "2026-04-08T04:34:48.325Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/82/959113a6351f3ca046cd0a8cd2cee071d7ea47473560557a01eeae9a6fe2/types_requests-2.33.0.20260503-py3-none-any.whl", hash = "sha256:02aaa7e3577a13471715bb1bddb693cc985ea514f754b503bf033e6a09a3e528", size = 20736, upload-time = "2026-05-03T05:20:07.858Z" },
 ]
 
 [[package]]
@@ -1678,11 +1678,11 @@ wheels = [
 
 [[package]]
 name = "wcwidth"
-version = "0.6.0"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
+    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-05-04`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [types-requests](https://pypi.org/project/types-requests/) | [`2.33.0.20260408` → `2.33.0.20260503`](https://github.com/python/typeshed/compare/v2.33.0.20260408...v2.33.0.20260503) | 2026-05-03 |
| [wcwidth](https://pypi.org/project/wcwidth/) | [`0.6.0` → `0.7.0`](https://github.com/jquast/wcwidth/compare/0.6.0...0.7.0) | 2026-05-02 |

### Release notes

<details>
<summary><code>types-requests</code></summary>

[Changelog](https://redirect.github.com/typeshed-internal/stub_uploader/blob/main/data/changelogs/requests.md)

</details>

<details>
<summary><code>wcwidth</code></summary>

#### [`0.7.0`](https://github.com/jquast/wcwidth/releases/tag/0.7.0)

  * **New** support for kitty text sizing protocol (OSC 66) in `width()` and `clip()`.
  * **New** `clip()` parameter ``control_codes='parse'``, ``'ignore'``, and ``'strict'``. `clip()`
    is now able to clip OSC 8 hyperlinks and OSC 66 text sizing sequences.
  * **Improved** `clip()` and `width()` to support horizontal cursor sequences (``cub``, ``cuf``,
    ``hpa``). Cursor-left (``cub``) or backspace (``\b``) now overwrites text.  column_address
    (``hpa``) and carriage return (``\r``) are now parsed, and more values conditionally raise
    ``ValueError`` when ``control_codes='strict'``.

## PR's

* Remove docs, add utils by @​jquast in https://redirect.github.com/jquast/wcwidth/pull/209
* Bump requests from 2.32.5 to 2.33.0 in /docs by @​dependabot[bot] in https://redirect.github.com/jquast/wcwidth/pull/210
* Bump pygments from 2.19.2 to 2.20.0 in /docs by @​dependabot[bot] in https://redirect.github.com/jquast/wcwidth/pull/212
* dependabot nonsense by @​jquast in https://redirect.github.com/jquast/wcwidth/pull/215
* Expand terminal escape sequence for three more ECMA-48 "families" by @​jquast in https://redirect.github.com/jquast/wcwidth/pull/214
* Improve clip() and width() with hyperlinks and overtyping by @​jquast in https://redirect.github.com/jquast/wcwidth/pull/216
* Improve width() and clip() with kitty Text Sizing Protocol by @​jquast in https://redirect.github.com/jquast/wcwidth/pull/213

**Full Changelog**: https://redirect.github.com/jquast/wcwidth/compare/0.6.0...0.7.0

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`430ccb27`](https://github.com/kdeldycke/click-extra/commit/430ccb277bbf5e6f000b9b82d22c03db2b673318) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/click-extra/blob/430ccb277bbf5e6f000b9b82d22c03db2b673318/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/430ccb277bbf5e6f000b9b82d22c03db2b673318/.github/workflows/autofix.yaml) |
| **Run** | [#2718.1](https://github.com/kdeldycke/click-extra/actions/runs/25674360766) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.16.0`