### PR TITLE
Format Python

### DIFF
--- a/click_extra/colorize.py
+++ b/click_extra/colorize.py
@@ -591,7 +591,10 @@ class HelpExtraFormatter(cloup.HelpFormatter):
         # implementation for multi-line wrapping. Bypass cloup's wrapper to
         # avoid double-styling ``prefix`` and ``prog``.
         click.formatting.HelpFormatter.write_usage(
-            self, styled_prog, args, styled_prefix,
+            self,
+            styled_prog,
+            args,
+            styled_prefix,
         )
 
     keywords: HelpKeywords = HelpKeywords()

--- a/click_extra/config.py
+++ b/click_extra/config.py
@@ -1885,8 +1885,7 @@ class ConfigOption(ExtraOption, ParamStructure):
             return normalized_conf
         app_name = self._app_section_name(ctx)
         prefixed_paths = (
-            f"{app_name}.{path}" if app_name else path
-            for path in self._opaque_paths
+            f"{app_name}.{path}" if app_name else path for path in self._opaque_paths
         )
         return _strip_opaque_subtrees(normalized_conf, prefixed_paths)
 
@@ -1999,13 +1998,9 @@ class ConfigOption(ExtraOption, ParamStructure):
                 # uniform error reporting across click-extra's own checks
                 # and user-registered validators.
                 prefix = (
-                    f"{app_name}.{cv.extension_path}"
-                    if app_name
-                    else cv.extension_path
+                    f"{app_name}.{cv.extension_path}" if app_name else cv.extension_path
                 )
-                rooted_path = (
-                    f"{prefix}.{exc.path}" if exc.path else prefix
-                )
+                rooted_path = f"{prefix}.{exc.path}" if exc.path else prefix
                 yield ValidationError(rooted_path, exc.message, exc.code)
 
     def _run_validators(
@@ -2362,9 +2357,7 @@ class ValidateConfigOption(ExtraOption):
         # 1. CLI-parameter strict check, with opaque sub-trees stripped so
         # user-controlled tables (e.g. dict[str, X] fields) don't trip the
         # unknown-key detector.
-        normalized = _expand_dotted_keys(
-            _strip_reserved_keys(user_conf), strict=True
-        )
+        normalized = _expand_dotted_keys(_strip_reserved_keys(user_conf), strict=True)
         normalized = config_option._strip_opaque_from_conf(ctx, normalized)
         try:
             _recursive_update(
@@ -2384,7 +2377,10 @@ class ValidateConfigOption(ExtraOption):
                 errors.append(str(exc))
 
         # 3. App-registered validators against opaque sub-trees.
-        errors.extend(str(verror) for verror in config_option._iter_validator_errors(ctx, user_conf))
+        errors.extend(
+            str(verror)
+            for verror in config_option._iter_validator_errors(ctx, user_conf)
+        )
 
         if errors:
             for err in errors:

--- a/click_extra/styling.py
+++ b/click_extra/styling.py
@@ -59,27 +59,33 @@ if TYPE_CHECKING:
 # (where ``bright_*`` named colors aren't valid CSS keywords) and by
 # :meth:`contrast_ratio` (which needs RGB to compute luminance).
 _ANSI_16_RGB: tuple[tuple[int, int, int], ...] = (
-    (0, 0, 0),         # 0: black
-    (170, 0, 0),       # 1: red
-    (0, 170, 0),       # 2: green
-    (170, 85, 0),      # 3: yellow
-    (0, 0, 170),       # 4: blue
-    (170, 0, 170),     # 5: magenta
-    (0, 170, 170),     # 6: cyan
-    (170, 170, 170),   # 7: white
-    (85, 85, 85),      # 8: bright_black
-    (255, 85, 85),     # 9: bright_red
-    (85, 255, 85),     # 10: bright_green
-    (255, 255, 85),    # 11: bright_yellow
-    (85, 85, 255),     # 12: bright_blue
-    (255, 85, 255),    # 13: bright_magenta
-    (85, 255, 255),    # 14: bright_cyan
-    (255, 255, 255),   # 15: bright_white
+    (0, 0, 0),  # 0: black
+    (170, 0, 0),  # 1: red
+    (0, 170, 0),  # 2: green
+    (170, 85, 0),  # 3: yellow
+    (0, 0, 170),  # 4: blue
+    (170, 0, 170),  # 5: magenta
+    (0, 170, 170),  # 6: cyan
+    (170, 170, 170),  # 7: white
+    (85, 85, 85),  # 8: bright_black
+    (255, 85, 85),  # 9: bright_red
+    (85, 255, 85),  # 10: bright_green
+    (255, 255, 85),  # 11: bright_yellow
+    (85, 85, 255),  # 12: bright_blue
+    (255, 85, 255),  # 13: bright_magenta
+    (85, 255, 255),  # 14: bright_cyan
+    (255, 255, 255),  # 15: bright_white
 )
 
 _ANSI_NAMES: tuple[str, ...] = (
-    "black", "red", "green", "yellow",
-    "blue", "magenta", "cyan", "white",
+    "black",
+    "red",
+    "green",
+    "yellow",
+    "blue",
+    "magenta",
+    "cyan",
+    "white",
 )
 
 # Channel values for the 6×6×6 color cube (palette indices 16–231).
@@ -87,8 +93,14 @@ _CUBE_VALUES: tuple[int, ...] = (0, 95, 135, 175, 215, 255)
 
 # Boolean style attributes processed in repr/css/from_ansi.
 _BOOL_ATTRS: tuple[str, ...] = (
-    "bold", "dim", "italic", "underline", "overline",
-    "blink", "reverse", "strikethrough",
+    "bold",
+    "dim",
+    "italic",
+    "underline",
+    "overline",
+    "blink",
+    "reverse",
+    "strikethrough",
 )
 
 # Match a single ANSI SGR escape: ``\x1b[...m``.
@@ -363,9 +375,7 @@ class Style(cloup.Style):
         """Hash mirroring :meth:`__eq__`: skip the lazy ``_style_kwargs`` cache."""
         return hash(
             tuple(
-                getattr(self, f.name)
-                for f in fields(self)
-                if f.name != "_style_kwargs"
+                getattr(self, f.name) for f in fields(self) if f.name != "_style_kwargs"
             )
         )
 
@@ -410,9 +420,7 @@ class Style(cloup.Style):
         keeps ``derived``'s overrides and inherits the rest from ``parent``.
         """
         if not isinstance(base, cloup.Style):
-            raise TypeError(
-                f"Cannot cascade onto {type(base).__name__}: not a Style."
-            )
+            raise TypeError(f"Cannot cascade onto {type(base).__name__}: not a Style.")
         return self._merge(base, self)
 
     @staticmethod

--- a/click_extra/theme.py
+++ b/click_extra/theme.py
@@ -504,7 +504,7 @@ _PALETTE_SKIP_SLOTS: frozenset[str] = frozenset({
 
 _PALETTE_SWATCH = (
     '<span style="display:inline-block;width:0.85em;height:0.85em;'
-    'background:{css};border:1px solid var(--color-foreground-muted,#888);'
+    "background:{css};border:1px solid var(--color-foreground-muted,#888);"
     'border-radius:2px;vertical-align:-0.15em;margin-right:0.35em"></span>'
 )
 
@@ -528,8 +528,16 @@ _PALETTE_ATTR_CSS: dict[str, str] = {
 # click-extra's local HelpExtraTheme autodoc anchor (which only covers the
 # slots HelpExtraTheme adds on top of cloup's base class).
 _PALETTE_CLOUP_SLOTS: frozenset[str] = frozenset({
-    "invoked_command", "command_help", "heading", "constraint",
-    "section_help", "col1", "col2", "alias", "alias_secondary", "epilog",
+    "invoked_command",
+    "command_help",
+    "heading",
+    "constraint",
+    "section_help",
+    "col1",
+    "col2",
+    "alias",
+    "alias_secondary",
+    "epilog",
 })
 
 # Per-slot example templates. Substrings wrapped in ``«…»`` (U+00AB / U+00BB
@@ -564,12 +572,9 @@ _PALETTE_EXAMPLES: dict[str, str] = {
         "  «backup»        Snapshot the data store.\n"
         "  «restore»       Restore from a snapshot."
     ),
-    "choice": (
-        "--format [«json»|«csv»|«xml»]   Output format. Defaults to «json»."
-    ),
+    "choice": ("--format [«json»|«csv»|«xml»]   Output format. Defaults to «json»."),
     "metavar": (
-        "--output «TEXT»       Destination file.\n"
-        "--workers «INTEGER»   Worker count."
+        "--output «TEXT»       Destination file.\n--workers «INTEGER»   Worker count."
     ),
     # The single wide marker covers the entire bracket field because
     # ``bracket`` is the runtime fallback for every inner slot (``envvar``,
@@ -593,8 +598,7 @@ _PALETTE_EXAMPLES: dict[str, str] = {
     ),
     "required": "--token TEXT    Authentication token.  [«required»]",
     "argument": (
-        "Usage: cp [OPTIONS] «SRC» «DST»\n"
-        "Usage: pack [OPTIONS] «[FILES]...» «[OUTPUT]»"
+        "Usage: cp [OPTIONS] «SRC» «DST»\nUsage: pack [OPTIONS] «[FILES]...» «[OUTPUT]»"
     ),
     "deprecated": (
         "--old-api    Legacy endpoint. «(DEPRECATED: use --new-api instead)»\n"
@@ -603,17 +607,14 @@ _PALETTE_EXAMPLES: dict[str, str] = {
     "search": "--«retry»-budget INTEGER    The «retry» budget.",
     "success": "«✓» database migration completed\n«✓» 1,245 records imported",
     "subheading": (
-        "«◼ 3 mails sharing hash a1b2c3d4»\n"
-        "«◼ 7 mails sharing hash e5f6a7b8»"
+        "«◼ 3 mails sharing hash a1b2c3d4»\n«◼ 7 mails sharing hash e5f6a7b8»"
     ),
 }
 
 # Matches a single ``«…»`` segment for the slot-example renderer.
 _PALETTE_EXAMPLE_RE: re.Pattern[str] = re.compile("«([^»]+)»")
 
-_PALETTE_CLOUP_URL = (
-    "https://cloup.readthedocs.io/en/stable/autoapi/cloup/index.html"
-)
+_PALETTE_CLOUP_URL = "https://cloup.readthedocs.io/en/stable/autoapi/cloup/index.html"
 
 
 def _palette_slot_link(name: str) -> str:
@@ -679,6 +680,7 @@ def inject_slot_example_docstring(
 
         from click_extra.theme import inject_slot_example_docstring
 
+
         def setup(app):
             app.connect("autodoc-process-docstring", inject_slot_example_docstring)
 
@@ -690,7 +692,7 @@ def inject_slot_example_docstring(
     prefix = "click_extra.theme.HelpExtraTheme."
     if not name.startswith(prefix):
         return
-    slot = name[len(prefix):]
+    slot = name[len(prefix) :]
     rendered = _render_slot_ansi(BUILTIN_THEMES["dark"], slot)
     if not rendered:
         return
@@ -699,8 +701,7 @@ def inject_slot_example_docstring(
     lines.append("")
     lines.append(".. code-block:: ansi-color")
     lines.append("")
-    for ansi_line in rendered.split("\n"):
-        lines.append(f"   {ansi_line}")
+    lines.extend(f"   {ansi_line}" for ansi_line in rendered.split("\n"))
 
 
 def _render_slot_example(theme: HelpExtraTheme, slot: str) -> str:
@@ -727,7 +728,7 @@ def _render_slot_example(theme: HelpExtraTheme, slot: str) -> str:
     last = 0
     for match in _PALETTE_EXAMPLE_RE.finditer(template):
         # Plain text between the previous segment and this match.
-        parts.append(html.escape(template[last:match.start()]))
+        parts.append(html.escape(template[last : match.start()]))
         token = html.escape(match.group(1))
         if css:
             parts.append(f'<span style="{css}">{token}</span>')
@@ -741,9 +742,7 @@ def _render_slot_example(theme: HelpExtraTheme, slot: str) -> str:
         '<pre class="slot-example" style="margin:0.3em 0 0;'
         "padding:0.4em 0.6em;background:var(--color-code-background,#f5f5f5);"
         "border-radius:4px;font-size:0.85em;line-height:1.4;"
-        'white-space:pre-wrap">'
-        + "".join(parts)
-        + "</pre>"
+        'white-space:pre-wrap">' + "".join(parts) + "</pre>"
     )
 
 
@@ -788,8 +787,7 @@ def palette_html(theme: HelpExtraTheme) -> str:
             else:
                 color_label = str(fg)
             cell_parts.append(
-                _PALETTE_SWATCH.format(css=css)
-                + f"<code>{color_label}</code>"
+                _PALETTE_SWATCH.format(css=css) + f"<code>{color_label}</code>"
             )
         attrs = [
             f'<span style="{css}">{name}</span>'
@@ -807,16 +805,11 @@ def palette_html(theme: HelpExtraTheme) -> str:
         body = " ".join(cell_parts) or "—"
         if example_html:
             body = body + example_html
-        rows.append(
-            f"<dt>{_palette_slot_link(f.name)}</dt>"
-            f"<dd>{body}</dd>"
-        )
+        rows.append(f"<dt>{_palette_slot_link(f.name)}</dt><dd>{body}</dd>")
     return (
         '<dl class="theme-palette" style="display:grid;'
         "grid-template-columns:max-content 1fr;gap:0.2em 1em;"
-        'margin:0.5em 0">'
-        + "".join(rows)
-        + "</dl>"
+        'margin:0.5em 0">' + "".join(rows) + "</dl>"
     )
 
 
@@ -837,8 +830,7 @@ def validate_themes_config(themes_subtree: dict[str, Any]) -> None:
             raise ValidationError(
                 path=name,
                 message=(
-                    f"theme definition must be a table, got "
-                    f"{type(slots).__name__}"
+                    f"theme definition must be a table, got {type(slots).__name__}"
                 ),
                 code="invalid-theme-shape",
             )
@@ -1012,8 +1004,13 @@ def _load_builtin_themes() -> dict[str, HelpExtraTheme]:
     zipped imports (PyOxidizer, PEX, certain Nuitka modes) where
     ``Path(__file__).parent`` doesn't resolve to a real filesystem location.
     """
-    payload = resources.files(__package__).joinpath("themes.toml").read_text(
-        encoding="utf-8",
+    payload = (
+        resources
+        .files(__package__)
+        .joinpath("themes.toml")
+        .read_text(
+            encoding="utf-8",
+        )
     )
     raw = tomllib.loads(payload)
     return {name: HelpExtraTheme.from_dict(data) for name, data in raw.items()}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4103,9 +4103,7 @@ def test_pyproject_toml_explicit_config_skips_cwd(
     assert "value is 'from_explicit'" in result.stdout
 
 
-def test_pyproject_toml_cwd_skips_unrelated_tool_section(
-    invoke, tmp_path, monkeypatch
-):
+def test_pyproject_toml_cwd_skips_unrelated_tool_section(invoke, tmp_path, monkeypatch):
     """A pyproject.toml without [tool.<cli_name>] is skipped.
 
     Regression: a pyproject.toml carrying only unrelated [tool.X] sections
@@ -4799,9 +4797,7 @@ def test_validate_config_skips_opaque_field(invoke, create_config):
 # during both --validate-config and normal --config loading.
 
 
-def test_config_validator_runs_and_fails_under_validate_config(
-    invoke, create_config
-):
+def test_config_validator_runs_and_fails_under_validate_config(invoke, create_config):
     """A registered ``ConfigValidator`` runs during ``--validate-config`` and
     surfaces its ``ValidationError`` with a path rooted at the config file."""
     from dataclasses import dataclass, field
@@ -4854,9 +4850,7 @@ def test_config_validator_runs_and_fails_under_validate_config(
             timeout = 30
             """),
     )
-    result = invoke(
-        validator_cli, "--validate-config", str(valid_path), color=False
-    )
+    result = invoke(validator_cli, "--validate-config", str(valid_path), color=False)
     assert result.exit_code == 0
     assert "is valid" in result.stderr
 
@@ -4872,9 +4866,7 @@ def test_config_validator_runs_and_fails_under_validate_config(
             badkey = "oops"
             """),
     )
-    result = invoke(
-        validator_cli, "--validate-config", str(invalid_path), color=False
-    )
+    result = invoke(validator_cli, "--validate-config", str(invalid_path), color=False)
     assert result.exit_code == 1
     assert "validator-cli.managers.winget.badkey: unknown field 'badkey'" in (
         result.stderr
@@ -5010,9 +5002,7 @@ def test_config_validator_collects_all_errors(invoke, create_config):
             """),
     )
 
-    result = invoke(
-        both_errors_cli, "--validate-config", str(conf_path), color=False
-    )
+    result = invoke(both_errors_cli, "--validate-config", str(conf_path), color=False)
     assert result.exit_code == 1
     # Both errors appear in the same run.
     assert "unknown_flag" in result.stderr

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -50,7 +50,10 @@ _THEME_BACKGROUNDS: dict[str, str] = {
 # can hold them to a real WCAG threshold. ANSI themes inherit terminal
 # rendering and only get the legibility floor below.
 _BRANDED_THEMES: tuple[str, ...] = (
-    "dracula", "monokai", "nord", "solarized_dark",
+    "dracula",
+    "monokai",
+    "nord",
+    "solarized_dark",
 )
 
 # Slots that carry primary readable text. These should clear WCAG AA Large
@@ -58,7 +61,10 @@ _BRANDED_THEMES: tuple[str, ...] = (
 # Strict AA (4.5) is unattainable for some themes (Solarized's #268bd2 on
 # #002b36 famously sits at 4.08), so AA Large is the realistic floor.
 _READABLE_SLOTS: tuple[str, ...] = (
-    "option", "error", "warning", "success",
+    "option",
+    "error",
+    "warning",
+    "success",
 )
 
 # Absolute legibility floor: anything below this is essentially invisible
@@ -239,11 +245,7 @@ def test_themechoice_choices_pick_up_context_overrides():
 
 @pytest.mark.parametrize(
     ("theme_name", "slot"),
-    [
-        (theme, slot)
-        for theme in _BRANDED_THEMES
-        for slot in _READABLE_SLOTS
-    ],
+    [(theme, slot) for theme in _BRANDED_THEMES for slot in _READABLE_SLOTS],
 )
 def test_branded_themes_meet_wcag_aa_large(theme_name, slot):
     """Branded themes' readable-text slots clear WCAG AA Large (3.0+).
@@ -288,9 +290,7 @@ def test_themes_meet_legibility_floor(theme_name):
             continue
         ratio = slot_value.contrast_ratio(bg_style)
         if ratio < _LEGIBILITY_FLOOR:
-            failures.append(
-                f"{theme_name}.{f.name} (fg={fg!r}) ratio={ratio:.2f}"
-            )
+            failures.append(f"{theme_name}.{f.name} (fg={fg!r}) ratio={ratio:.2f}")
     assert not failures, (
         f"Slots below the legibility floor ({_LEGIBILITY_FLOOR}) on "
         f"{_THEME_BACKGROUNDS[theme_name]}: " + ", ".join(failures)


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`decadb6a`](https://github.com/kdeldycke/click-extra/commit/decadb6aff61a758f5b4ec1fbe32b862a2d122e6) |
| **Job** | [`format-python`](https://github.com/kdeldycke/click-extra/blob/decadb6aff61a758f5b4ec1fbe32b862a2d122e6/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/decadb6aff61a758f5b4ec1fbe32b862a2d122e6/.github/workflows/autofix.yaml) |
| **Run** | [#2732.1](https://github.com/kdeldycke/click-extra/actions/runs/25875665089) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.16.0`