### PR TITLE
Format Markdown

### DIFF
--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -118,27 +118,27 @@ c()
 
 Every default option ships with a matching decorator built via `decorator_factory`:
 
-| Decorator                  | Wraps                                                          |
-| -------------------------- | -------------------------------------------------------------- |
-| `command`                  | `cloup.command(cls=ExtraCommand, params=default_extra_params)` |
-| `group`                    | `cloup.group(cls=ExtraGroup, params=default_extra_params)`     |
-| `lazy_group`               | `group(cls=LazyGroup)`                                         |
-| `option`                   | `cloup.option(cls=Option)`                                     |
-| `argument`                 | `cloup.argument(cls=Argument)`                                 |
-| `help_option`              | `click.decorators.help_option(*DEFAULT_HELP_NAMES)`            |
-| `version_option`           | `option(cls=ExtraVersionOption)`                               |
-| `color_option`             | `option(cls=ColorOption)`                                      |
-| `config_option`            | `option(cls=ConfigOption)`                                     |
-| `no_config_option`         | `option(cls=NoConfigOption)`                                   |
-| `validate_config_option`   | `option(cls=ValidateConfigOption)`                             |
-| `jobs_option`              | `option(cls=JobsOption)`                                       |
-| `show_params_option`       | `option(cls=ShowParamsOption)`                                 |
-| `table_format_option`      | `option(cls=TableFormatOption)`                                |
-| `telemetry_option`         | `option(cls=TelemetryOption)`                                  |
-| `theme_option`             | `option(cls=ThemeOption)`                                      |
-| `timer_option`             | `option(cls=TimerOption)`                                      |
-| `verbose_option`           | `option(cls=VerboseOption)`                                    |
-| `verbosity_option`         | `option(cls=VerbosityOption)`                                  |
+| Decorator                | Wraps                                                          |
+| ------------------------ | -------------------------------------------------------------- |
+| `command`                | `cloup.command(cls=ExtraCommand, params=default_extra_params)` |
+| `group`                  | `cloup.group(cls=ExtraGroup, params=default_extra_params)`     |
+| `lazy_group`             | `group(cls=LazyGroup)`                                         |
+| `option`                 | `cloup.option(cls=Option)`                                     |
+| `argument`               | `cloup.argument(cls=Argument)`                                 |
+| `help_option`            | `click.decorators.help_option(*DEFAULT_HELP_NAMES)`            |
+| `version_option`         | `option(cls=ExtraVersionOption)`                               |
+| `color_option`           | `option(cls=ColorOption)`                                      |
+| `config_option`          | `option(cls=ConfigOption)`                                     |
+| `no_config_option`       | `option(cls=NoConfigOption)`                                   |
+| `validate_config_option` | `option(cls=ValidateConfigOption)`                             |
+| `jobs_option`            | `option(cls=JobsOption)`                                       |
+| `show_params_option`     | `option(cls=ShowParamsOption)`                                 |
+| `table_format_option`    | `option(cls=TableFormatOption)`                                |
+| `telemetry_option`       | `option(cls=TelemetryOption)`                                  |
+| `theme_option`           | `option(cls=ThemeOption)`                                      |
+| `timer_option`           | `option(cls=TimerOption)`                                      |
+| `verbose_option`         | `option(cls=VerboseOption)`                                    |
+| `verbosity_option`       | `option(cls=VerbosityOption)`                                  |
 
 Every entry in this list is an `allow_missing_parenthesis`-wrapped factory, so `@theme_option` and `@theme_option()` are both legal, and `@theme_option(default="light")` overrides the default while keeping the click-extra subclass guarantee.
 

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -106,17 +106,17 @@ print(Style(fg="cyan", dim=True).to_css())
 
 The mapping is:
 
-| Attribute       | CSS declaration                  |
-| --------------- | -------------------------------- |
-| `fg`            | `color: <color>`                 |
-| `bg`            | `background-color: <color>`      |
-| `bold`          | `font-weight: bold`              |
-| `italic`        | `font-style: italic`             |
-| `underline`     | `text-decoration: underline`     |
-| `overline`      | `text-decoration: overline`      |
-| `strikethrough` | `text-decoration: line-through`  |
-| `dim`           | `opacity: 0.6`                   |
-| `reverse`       | `filter: invert(1)`              |
+| Attribute       | CSS declaration                 |
+| --------------- | ------------------------------- |
+| `fg`            | `color: <color>`                |
+| `bg`            | `background-color: <color>`     |
+| `bold`          | `font-weight: bold`             |
+| `italic`        | `font-style: italic`            |
+| `underline`     | `text-decoration: underline`    |
+| `overline`      | `text-decoration: overline`     |
+| `strikethrough` | `text-decoration: line-through` |
+| `dim`           | `opacity: 0.6`                  |
+| `reverse`       | `filter: invert(1)`             |
 
 `underline`, `overline` and `strikethrough` collapse into a single `text-decoration` declaration when more than one is set.
 

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -36,14 +36,14 @@ Now invocations of the `weather` CLI pick up the light theme without passing `--
 
 ## Built-in themes
 
-| Name                                  | Color model          | Notes                                                                |
-| :------------------------------------ | :------------------- | :------------------------------------------------------------------- |
-| [`dark`](#dark)                       | 16 named ANSI colors | Process-wide default. Follows the user's terminal palette.           |
-| [`light`](#light)                     | 16 named ANSI colors | Tuned for white backgrounds: no bright variants, blue replaces cyan. |
-| [`solarized_dark`](#solarized-dark)   | 24-bit RGB           | Warm-toned dark theme with selective accent contrast.                |
-| [`dracula`](#dracula)                 | 24-bit RGB           | High-contrast dark theme with vivid neon accents.                    |
-| [`nord`](#nord)                       | 24-bit RGB           | Cool-toned dark theme built around frost-blue and aurora accents.    |
-| [`monokai`](#monokai)                 | 24-bit RGB           | Classic dark theme with high-saturation magenta and lime accents.    |
+| Name                                | Color model          | Notes                                                                |
+| :---------------------------------- | :------------------- | :------------------------------------------------------------------- |
+| [`dark`](#dark)                     | 16 named ANSI colors | Process-wide default. Follows the user's terminal palette.           |
+| [`light`](#light)                   | 16 named ANSI colors | Tuned for white backgrounds: no bright variants, blue replaces cyan. |
+| [`solarized_dark`](#solarized-dark) | 24-bit RGB           | Warm-toned dark theme with selective accent contrast.                |
+| [`dracula`](#dracula)               | 24-bit RGB           | High-contrast dark theme with vivid neon accents.                    |
+| [`nord`](#nord)                     | 24-bit RGB           | Cool-toned dark theme built around frost-blue and aurora accents.    |
+| [`monokai`](#monokai)               | 24-bit RGB           | Classic dark theme with high-saturation magenta and lime accents.    |
 
 Each row is keyed by the `--theme` choice value; access the instance via `BUILTIN_THEMES["<name>"]` (e.g. `BUILTIN_THEMES["dark"]`). Click any name to jump to that theme's [palette listing](#palettes) below.
 
@@ -314,7 +314,7 @@ Malformed entries surface as `ValidationError` with a path rooted at the configu
 
 ```toml
 [weather.themes.midnight]
-optoin = { fg = "blue" }   # typo
+optoin = { fg = "blue" } # typo
 ```
 
 ```{click:run}

--- a/docs/version.md
+++ b/docs/version.md
@@ -369,26 +369,26 @@ All subcommands auto-discover target files from `[project.scripts]` in `pyprojec
 
 Each variable listed in the section above can be rendered in its own style. They all have dedicated parameters you can pass to the `version_option` decorator:
 
-| Parameter               | Description                             | Default Style                             |
-| ----------------------- | --------------------------------------- | ----------------------------------------- |
-| `message_style`         | Style of the whole message.             | `None`{l=python}                          |
-| `module_style`          | Style for `{module}` variable.          | `None`{l=python}                          |
+| Parameter               | Description                             | Default Style                                      |
+| ----------------------- | --------------------------------------- | -------------------------------------------------- |
+| `message_style`         | Style of the whole message.             | `None`{l=python}                                   |
+| `module_style`          | Style for `{module}` variable.          | `None`{l=python}                                   |
 | `module_name_style`     | Style for `{module_name}` variable.     | `BUILTIN_THEMES["dark"].invoked_command`{l=python} |
-| `module_file_style`     | Style for `{module_file}` variable.     | `None`{l=python}                          |
-| `module_version_style`  | Style for `{module_version}` variable.  | `Style(fg="green")`{l=python}             |
+| `module_file_style`     | Style for `{module_file}` variable.     | `None`{l=python}                                   |
+| `module_version_style`  | Style for `{module_version}` variable.  | `Style(fg="green")`{l=python}                      |
 | `package_name_style`    | Style for `{package_name}` variable.    | `BUILTIN_THEMES["dark"].invoked_command`{l=python} |
-| `package_version_style` | Style for `{package_version}` variable. | `Style(fg="green")`{l=python}             |
+| `package_version_style` | Style for `{package_version}` variable. | `Style(fg="green")`{l=python}                      |
 | `exec_name_style`       | Style for `{exec_name}` variable.       | `BUILTIN_THEMES["dark"].invoked_command`{l=python} |
-| `version_style`         | Style for `{version}` variable.         | `Style(fg="green")`{l=python}             |
-| `git_repo_path_style`   | Style for `{git_repo_path}` variable.   | `Style(fg="bright_black")`{l=python}      |
-| `git_branch_style`      | Style for `{git_branch}` variable.      | `Style(fg="cyan")`{l=python}              |
-| `git_long_hash_style`   | Style for `{git_long_hash}` variable.   | `Style(fg="yellow")`{l=python}            |
-| `git_short_hash_style`  | Style for `{git_short_hash}` variable.  | `Style(fg="yellow")`{l=python}            |
-| `git_date_style`        | Style for `{git_date}` variable.        | `Style(fg="bright_black")`{l=python}      |
-| `git_tag_style`         | Style for `{git_tag}` variable.         | `Style(fg="cyan")`{l=python}              |
-| `git_tag_sha_style`     | Style for `{git_tag_sha}` variable.     | `Style(fg="yellow")`{l=python}            |
+| `version_style`         | Style for `{version}` variable.         | `Style(fg="green")`{l=python}                      |
+| `git_repo_path_style`   | Style for `{git_repo_path}` variable.   | `Style(fg="bright_black")`{l=python}               |
+| `git_branch_style`      | Style for `{git_branch}` variable.      | `Style(fg="cyan")`{l=python}                       |
+| `git_long_hash_style`   | Style for `{git_long_hash}` variable.   | `Style(fg="yellow")`{l=python}                     |
+| `git_short_hash_style`  | Style for `{git_short_hash}` variable.  | `Style(fg="yellow")`{l=python}                     |
+| `git_date_style`        | Style for `{git_date}` variable.        | `Style(fg="bright_black")`{l=python}               |
+| `git_tag_style`         | Style for `{git_tag}` variable.         | `Style(fg="cyan")`{l=python}                       |
+| `git_tag_sha_style`     | Style for `{git_tag_sha}` variable.     | `Style(fg="yellow")`{l=python}                     |
 | `prog_name_style`       | Style for `{prog_name}` variable.       | `BUILTIN_THEMES["dark"].invoked_command`{l=python} |
-| `env_info_style`        | Style for `{env_info}` variable.        | `Style(fg="bright_black")`{l=python}      |
+| `env_info_style`        | Style for `{env_info}` variable.        | `Style(fg="bright_black")`{l=python}               |
 
 Here is an example:
 


### PR DESCRIPTION
### Description

Auto-formats Markdown files with [mdformat](https://github.com/hukkin/mdformat) and its plugins. See the [`format-markdown` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize Markdown formatting via [`[tool.mdformat]`](https://mdformat.readthedocs.io/en/stable/users/configuration_file.html) in your `pyproject.toml`, or via a native `.mdformat.toml` file.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`decadb6a`](https://github.com/kdeldycke/click-extra/commit/decadb6aff61a758f5b4ec1fbe32b862a2d122e6) |
| **Job** | [`format-markdown`](https://github.com/kdeldycke/click-extra/blob/decadb6aff61a758f5b4ec1fbe32b862a2d122e6/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/decadb6aff61a758f5b4ec1fbe32b862a2d122e6/.github/workflows/autofix.yaml) |
| **Run** | [#2732.1](https://github.com/kdeldycke/click-extra/actions/runs/25875665089) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.16.0`