### PR TITLE
Sync `uv.lock`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -279,7 +279,6 @@ dependency-groups.docs = { requires-python = ">= 3.14" }
 # Relative dates are fine here because the Renovate lock-maintenance job
 # (sync-uv-lock) reverts uv.lock when the only diff is timestamp noise.
 exclude-newer = "1 week"
-exclude-newer-package = { urllib3 = "0 day" }
 # Package is at root level, not in "./src/".
 build-backend.module-root = ""
 

--- a/uv.lock
+++ b/uv.lock
@@ -12,9 +12,6 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P1W"
 
-[options.exclude-newer-package]
-urllib3 = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-
 [[package]]
 name = "accessible-pygments"
 version = "0.0.5"
@@ -580,7 +577,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -747,7 +744,7 @@ wheels = [
 
 [[package]]
 name = "markdown-it-py"
-version = "4.0.0"
+version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -757,9 +754,9 @@ resolution-markers = [
 dependencies = [
     { name = "mdurl", marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
 [[package]]
@@ -849,15 +846,15 @@ wheels = [
 
 [[package]]
 name = "mdit-py-plugins"
-version = "0.5.0"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "markdown-it-py", version = "4.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/3d/e0e8d9d1cee04f758120915e2b2a3a07eb41f8cf4654b4734788a522bcd1/mdit_py_plugins-0.6.0.tar.gz", hash = "sha256:2436f14a7295837ac9228a36feeabda867c4abc488c8d019ad5c0bda88eee040", size = 56025, upload-time = "2026-05-07T12:20:42.295Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205, upload-time = "2025-08-11T07:25:47.597Z" },
+    { url = "https://files.pythonhosted.org/packages/71/d6/48f5b9e44e2e760855d7b489b1317cd7620e82dcb73197961e5cc1391348/mdit_py_plugins-0.6.0-py3-none-any.whl", hash = "sha256:f7e7a25d8b616fee99cb1e330da73451d11a8061baf39bb9663ab9ce0e005b90", size = 66655, upload-time = "2026-05-07T12:20:41.226Z" },
 ]
 
 [[package]]
@@ -961,7 +958,7 @@ resolution-markers = [
 dependencies = [
     { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "jinja2", marker = "python_full_version >= '3.11'" },
-    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "markdown-it-py", version = "4.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "mdit-py-plugins", marker = "python_full_version >= '3.11'" },
     { name = "pyyaml", marker = "python_full_version >= '3.11'" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-05-07`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [markdown-it-py](https://pypi.org/project/markdown-it-py/) | [`4.0.0` → `4.2.0`](https://github.com/executablebooks/markdown-it-py/compare/v4.0.0...v4.2.0) | 2026-05-07 |
| [mdit-py-plugins](https://pypi.org/project/mdit-py-plugins/) | [`0.5.0` → `0.6.0`](https://github.com/executablebooks/mdit-py-plugins/compare/v0.5.0...v0.6.0) | 2026-05-07 |

### Release notes

<details>
<summary><code>markdown-it-py</code></summary>

#### [`v4.1.0`](https://github.com/executablebooks/markdown-it-py/releases/tag/v4.1.0)

## What's Changed
* ✨ Add `--stdin` option to CLI by @​mcepl in https://redirect.github.com/executablebooks/markdown-it-py/pull/379
* Add AGENTS.md and copilot-setup-steps workflow by @​Copilot in https://redirect.github.com/executablebooks/markdown-it-py/pull/380
* 🔧 Add typing to Scanner by @​Alunderin in https://redirect.github.com/executablebooks/markdown-it-py/pull/382
* 👌 Fix quadratic complexity in `fragments_join` / `text_join` by @​petricevich in https://redirect.github.com/executablebooks/markdown-it-py/pull/389
* ✨Allow plugins to register inline terminator characters by @​Copilot in https://redirect.github.com/executablebooks/markdown-it-py/pull/391
* ✨ Add `gfm-like2` preset with task lists, alerts, and single-tilde strikethrough by @​chrisjsewell in https://redirect.github.com/executablebooks/markdown-it-py/pull/388
* 🔧 Update pre-commit hooks by @​chrisjsewell in https://redirect.github.com/executablebooks/markdown-it-py/pull/392
* 🚀 RELEASE v4.1.0 by @​chrisjsewell in https://redirect.github.com/executablebooks/markdown-it-py/pull/393

## New Contributors
* @​mcepl made their first contribution in https://redirect.github.com/executablebooks/markdown-it-py/pull/379
* @​Copilot made their first contribution in https://redirect.github.com/executablebooks/markdown-it-py/pull/380
* @​Alunderin made their first contribution in https://redirect.github.com/executablebooks/markdown-it-py/pull/382
* @​petricevich made their first contribution in https://redirect.github.com/executablebooks/markdown-it-py/pull/389

**Full Changelog**: https://redirect.github.com/executablebooks/markdown-it-py/compare/v4.0.0...v4.1.0

#### [`v4.2.0`](https://github.com/executablebooks/markdown-it-py/releases/tag/v4.2.0)

## What's Changed
* ✨ Add `make_fence_rule()` factory for configurable fence markers by @​chrisjsewell in https://redirect.github.com/executablebooks/markdown-it-py/pull/394
* 🚀 RELEASE v4.2.0 by @​chrisjsewell in https://redirect.github.com/executablebooks/markdown-it-py/pull/395


**Full Changelog**: https://redirect.github.com/executablebooks/markdown-it-py/compare/v4.1.0...v4.2.0

</details>

<details>
<summary><code>mdit-py-plugins</code></summary>

#### [`v0.6.0`](https://github.com/executablebooks/mdit-py-plugins/releases/tag/v0.6.0)

## What's Changed
* 🔧 Add AGENTS.md and copilot-setup-steps workflow by @​Copilot in https://redirect.github.com/executablebooks/mdit-py-plugins/pull/132
* ✨ NEW: Add superscript plugin and tests by @​elijahgreenstein in https://redirect.github.com/executablebooks/mdit-py-plugins/pull/128
* ✨ Add GFM autolink and composite GFM plugins by @​chrisjsewell in https://redirect.github.com/executablebooks/mdit-py-plugins/pull/135
* 🔧 Fix pre-commit by @​chrisjsewell in https://redirect.github.com/executablebooks/mdit-py-plugins/pull/136
* 🚀 Release v0.6.0 by @​chrisjsewell in https://redirect.github.com/executablebooks/mdit-py-plugins/pull/137

## New Contributors
* @​Copilot made their first contribution in https://redirect.github.com/executablebooks/mdit-py-plugins/pull/132
* @​elijahgreenstein made their first contribution in https://redirect.github.com/executablebooks/mdit-py-plugins/pull/128

**Full Changelog**: https://redirect.github.com/executablebooks/mdit-py-plugins/compare/v0.5.0...v0.6.0

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `workflow_dispatch` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`69148e12`](https://github.com/kdeldycke/click-extra/commit/69148e1215cc8cb11058300a26aeb5c95083ae88) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/click-extra/blob/69148e1215cc8cb11058300a26aeb5c95083ae88/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/69148e1215cc8cb11058300a26aeb5c95083ae88/.github/workflows/autofix.yaml) |
| **Run** | [#2730.1](https://github.com/kdeldycke/click-extra/actions/runs/25873069385) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.16.0`