### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1548,41 +1548,41 @@ wheels = [
 
 [[package]]
 name = "types-boltons"
-version = "25.0.0.20260508"
+version = "25.0.0.20260518"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/60/5a/daec1e65fbbe6672a7e3691f0f989efcf6e0de8c62cf5861d9240ab1e606/types_boltons-25.0.0.20260508.tar.gz", hash = "sha256:c659fbe610768b7c1268d4e7cd0ede5f51cfc10767b76f155f7f9f6442cf08ec", size = 21806, upload-time = "2026-05-08T04:49:52.13Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/14/0bb319ee28c0b98042b16029877defe2378d2a82d44f28bee60684647d07/types_boltons-25.0.0.20260518.tar.gz", hash = "sha256:32cb6f76a7b795c89a1007b47e5cbf46e1d165c053df5b15bc2c6a508bb84795", size = 21876, upload-time = "2026-05-18T06:03:04.737Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/f3/4cdaf48f900cff162ad9647ab873db2d66d884ac75786d8d9dabe83d45a3/types_boltons-25.0.0.20260508-py3-none-any.whl", hash = "sha256:0153891cadf1924167899d478612072e57631ec93c6731b1bebb69ca24bc63a3", size = 28267, upload-time = "2026-05-08T04:49:51.043Z" },
+    { url = "https://files.pythonhosted.org/packages/03/57/32c268c4d805c20c56ea826b3f50a349004039a48b7feb116715e2049b82/types_boltons-25.0.0.20260518-py3-none-any.whl", hash = "sha256:f1309216d8956c4e7b2ddf049c07d15c3dc5455bce79659815c1958d187fec10", size = 28295, upload-time = "2026-05-18T06:03:03.379Z" },
 ]
 
 [[package]]
 name = "types-docutils"
-version = "0.22.3.20260508"
+version = "0.22.3.20260518"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/fa/38121f440851d813099c73296219e1b7be327cdd5b250b171744053dc87e/types_docutils-0.22.3.20260508.tar.gz", hash = "sha256:f043dd1fffad161cb671b0e3bf593bb5229b8d40bf365ac7d8337296dc97e6bc", size = 57431, upload-time = "2026-05-08T04:46:34.541Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/91/81b520d0869a41aa0d86e713417b63e8604b4280c304bc09b02d74c7efd4/types_docutils-0.22.3.20260518.tar.gz", hash = "sha256:2c45ba63a9ac64246335359b68fe9c27602926499c9b67caec3780745f6aadee", size = 57504, upload-time = "2026-05-18T06:03:53.325Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/07/f407403b94fc80a22e9ff9c31f17d78a3272f6cce9773081fbaf853a09e7/types_docutils-0.22.3.20260508-py3-none-any.whl", hash = "sha256:47bbac43bee53bcaf99f12f5b4253bf864777c31ac4eda6e3bf6660aa6ceac40", size = 91919, upload-time = "2026-05-08T04:46:33.336Z" },
+    { url = "https://files.pythonhosted.org/packages/01/9b/243fb84ede4f987f303a89e734c5def35ead2f8bd962ad301c1e99680958/types_docutils-0.22.3.20260518-py3-none-any.whl", hash = "sha256:9c4cbc37d9e37f47dfe971ac09e9880380dc948ff1f23956892e810d0bf08676", size = 91970, upload-time = "2026-05-18T06:03:52.388Z" },
 ]
 
 [[package]]
 name = "types-pygments"
-version = "2.20.0.20260508"
+version = "2.20.0.20260518"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "types-docutils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/9c/b5c7f3d26108e88594d5d5fa0aaae7edab0ad3e90746cb212a1548f58820/types_pygments-2.20.0.20260508.tar.gz", hash = "sha256:6ec4e232784e427eea12e798fe28d5a28321023937795527a94582d5f56feed7", size = 21102, upload-time = "2026-05-08T04:50:34.545Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/66/3e27e8dbe72947d51355d1fcba222a55bf5f0770ee660e9cc9df0d1ce5d7/types_pygments-2.20.0.20260518.tar.gz", hash = "sha256:bcab233d0389cb0a91146eb860e7bdcbceaa0f30bee73cefc7b367129cc4a330", size = 21152, upload-time = "2026-05-18T06:07:26.927Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/e6/767672dd4df860550da0aade55ea5b4e6244b3f58edc209f0bb36dca55f2/types_pygments-2.20.0.20260508-py3-none-any.whl", hash = "sha256:42d9c45f3397a46bdb7bf718d9fe9c2d001c842ffa5afe748a4d7a5b5f0708fe", size = 28989, upload-time = "2026-05-08T04:50:33.354Z" },
+    { url = "https://files.pythonhosted.org/packages/66/d6/5f19f5b633af6a7666c6096fdd06b70f0d4a8f585af5e18a3ef58ad47ec1/types_pygments-2.20.0.20260518-py3-none-any.whl", hash = "sha256:e40728efd00c9da5936366648d5b3c55e72ed52bdd80495a96577b4d717c4fcb", size = 29002, upload-time = "2026-05-18T06:07:26.054Z" },
 ]
 
 [[package]]
 name = "types-pyyaml"
-version = "6.0.12.20260510"
+version = "6.0.12.20260518"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/36/85/0d9fafce21be112e977a89677f1ce9d1aef921d745b17c758c93e861c11f/types_pyyaml-6.0.12.20260510.tar.gz", hash = "sha256:09c1f1cb65a6eebea1e2e51ccf4918b8288e152909609a35cdb0d805efd125ad", size = 17831, upload-time = "2026-05-10T05:26:28.136Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/ad/fd618a218925daada7b8a5e7326e662599fa5fdff4a4c44ab2795bd2d9ca/types_pyyaml-6.0.12.20260510-py3-none-any.whl", hash = "sha256:3492eb9ba4d9d833473214c4d5736cccf5f37d93f5854059721e1c84f785309d", size = 20304, upload-time = "2026-05-10T05:26:26.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
 ]
 
 [[package]]
@@ -1596,11 +1596,11 @@ wheels = [
 
 [[package]]
 name = "types-xmltodict"
-version = "1.0.1.20260508"
+version = "1.0.1.20260518"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/92/21/57f03cfff0af1e2b946b980d940d96c35f4a98ea4577588f81b1e3ec31a0/types_xmltodict-1.0.1.20260508.tar.gz", hash = "sha256:4e37ffbd0f0255f0312d7677194cc63ed745f6c5dfcb303073ab75dfcfe51c83", size = 8874, upload-time = "2026-05-08T04:49:27.44Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/b8/5c43e147eec89125e3f56670c86bc6ba8ea4d0c4cb738a77b3f46940e50d/types_xmltodict-1.0.1.20260518.tar.gz", hash = "sha256:b9d0b364dc47508b4c9040635a94c28f5472f9ab588f6c864ae4c96823bccb33", size = 8890, upload-time = "2026-05-18T06:03:00.296Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/fa/3273397fa7ed6ee84394d0ca6323cd3ebeac3308ee0e1556b80b217c1a60/types_xmltodict-1.0.1.20260508-py3-none-any.whl", hash = "sha256:9268dfd98bd6dfff4cdbc215d33efd50a61d20855bf1a3aa93dcc3cc38debf5c", size = 8375, upload-time = "2026-05-08T04:49:26.318Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/5d/e0eee00dd3c7299c1f5ae7ef596409c51dba4af93cfaf05ea7d27f4afc7d/types_xmltodict-1.0.1.20260518-py3-none-any.whl", hash = "sha256:b396dd53afbd8b034014922b95333f10d12515566a6a08282d39fdb1a3a529b9", size = 8377, upload-time = "2026-05-18T06:02:59.076Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-05-18`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [types-boltons](https://pypi.org/project/types-boltons/) | [`25.0.0.20260508` → `25.0.0.20260518`](https://github.com/python/typeshed/compare/v25.0.0.20260508...v25.0.0.20260518) | 2026-05-18 |
| [types-docutils](https://pypi.org/project/types-docutils/) | [`0.22.3.20260508` → `0.22.3.20260518`](https://github.com/python/typeshed/compare/v0.22.3.20260508...v0.22.3.20260518) | 2026-05-18 |
| [types-pygments](https://pypi.org/project/types-pygments/) | [`2.20.0.20260508` → `2.20.0.20260518`](https://github.com/python/typeshed/compare/v2.20.0.20260508...v2.20.0.20260518) | 2026-05-18 |
| [types-pyyaml](https://pypi.org/project/types-pyyaml/) | [`6.0.12.20260510` → `6.0.12.20260518`](https://github.com/python/typeshed/compare/v6.0.12.20260510...v6.0.12.20260518) | 2026-05-18 |
| [types-xmltodict](https://pypi.org/project/types-xmltodict/) | [`1.0.1.20260508` → `1.0.1.20260518`](https://github.com/python/typeshed/compare/v1.0.1.20260508...v1.0.1.20260518) | 2026-05-18 |

### Release notes

<details>
<summary><code>types-boltons</code></summary>

[Changelog](https://redirect.github.com/typeshed-internal/stub_uploader/blob/main/data/changelogs/boltons.md)

</details>

<details>
<summary><code>types-docutils</code></summary>

[Changelog](https://redirect.github.com/typeshed-internal/stub_uploader/blob/main/data/changelogs/docutils.md)

</details>

<details>
<summary><code>types-pygments</code></summary>

[Changelog](https://redirect.github.com/typeshed-internal/stub_uploader/blob/main/data/changelogs/Pygments.md)

</details>

<details>
<summary><code>types-pyyaml</code></summary>

[Changelog](https://redirect.github.com/typeshed-internal/stub_uploader/blob/main/data/changelogs/PyYAML.md)

</details>

<details>
<summary><code>types-xmltodict</code></summary>

[Changelog](https://redirect.github.com/typeshed-internal/stub_uploader/blob/main/data/changelogs/xmltodict.md)

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`ebe43e28`](https://github.com/kdeldycke/click-extra/commit/ebe43e28b8808ebc0a8a7eec24c682d3b0c2dc33) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/click-extra/blob/ebe43e28b8808ebc0a8a7eec24c682d3b0c2dc33/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/ebe43e28b8808ebc0a8a7eec24c682d3b0c2dc33/.github/workflows/autofix.yaml) |
| **Run** | [#2765.1](https://github.com/kdeldycke/click-extra/actions/runs/26397430273) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.19.0`