### PR TITLE
Format Python

### DIFF
--- a/click_extra/theme.py
+++ b/click_extra/theme.py
@@ -341,16 +341,14 @@ class HelpExtraTheme(cloup.HelpTheme):
         return type(self).from_dict(merged)
 
 
-LITERAL_STYLES: frozenset[str] = frozenset(
-    {
-        "invoked_command",
-        "subcommand",
-        "alias",
-        "alias_secondary",
-        "option",
-        "choice",
-    }
-)
+LITERAL_STYLES: frozenset[str] = frozenset({
+    "invoked_command",
+    "subcommand",
+    "alias",
+    "alias_secondary",
+    "option",
+    "choice",
+})
 r"""Names of the :class:`HelpExtraTheme` slots that color *literal* tokens:
 text the user types verbatim on the command line.
 
@@ -375,12 +373,10 @@ that the literal/replaceable dichotomy does not classify (log levels,
     the man-page generation gap.
 """
 
-REPLACEABLE_STYLES: frozenset[str] = frozenset(
-    {
-        "metavar",
-        "argument",
-    }
-)
+REPLACEABLE_STYLES: frozenset[str] = frozenset({
+    "metavar",
+    "argument",
+})
 r"""Names of the :class:`HelpExtraTheme` slots that color *replaceable* tokens:
 placeholders the user substitutes with a real value.
 


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`ebe43e28`](https://github.com/kdeldycke/click-extra/commit/ebe43e28b8808ebc0a8a7eec24c682d3b0c2dc33) |
| **Job** | [`format-python`](https://github.com/kdeldycke/click-extra/blob/ebe43e28b8808ebc0a8a7eec24c682d3b0c2dc33/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/ebe43e28b8808ebc0a8a7eec24c682d3b0c2dc33/.github/workflows/autofix.yaml) |
| **Run** | [#2765.1](https://github.com/kdeldycke/click-extra/actions/runs/26397430273) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.19.0`