### PR TITLE
Sync `bump-my-version` config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -417,9 +417,14 @@ glob = "./**/__init__.py"
 ignore_missing_version = true
 
 [[tool.bumpversion.files]]
-# Update version in [project] section.
+# Update version in [project] section. Anchored to a line start (regex) so it
+# does not also match version-suffixed keys like file-version/product-version
+# under [tool.nuitka], which contain `version = "X"` as a substring (their
+# values collide with the package version on release commits, where the .devN
+# suffix is absent).
 filename = "./pyproject.toml"
-search = 'version = "{current_version}"'
+regex = true
+search = '(?m)^version = "{current_version}"'
 replace = 'version = "{new_version}"'
 
 [[tool.bumpversion.files]]
@@ -427,6 +432,17 @@ replace = 'version = "{new_version}"'
 filename = "./pyproject.toml"
 search = "releases/tag/v{current_version}"
 replace = "releases/tag/v{new_version}"
+
+[[tool.bumpversion.files]]
+# Keep the numeric file-version/product-version under [tool.nuitka] in sync,
+# when present. Nuitka rejects PEP 440 .devN suffixes, so the file-specific
+# serialize strips them; the `-version = "` prefix matches both keys at once.
+# ignore_missing_version makes this a no-op in projects without [tool.nuitka].
+filename = "./pyproject.toml"
+ignore_missing_version = true
+serialize = [ "{major}.{minor}.{patch}" ]
+search = '-version = "{current_version}"'
+replace = '-version = "{new_version}"'
 
 [[tool.bumpversion.files]]
 # Update the version in Markdown changelog.


### PR DESCRIPTION
### Description

Initializes the `[tool.bumpversion]` configuration in `pyproject.toml` from the [bundled template](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/bumpversion.toml). See the [`sync-bumpversion` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`bumpversion.sync`](https://kdeldycke.github.io/repomatic/configuration.html#bumpversion-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`1dd31577`](https://github.com/kdeldycke/click-extra/commit/1dd31577e87f2a5d2837dcd1db5f96f05672666f) |
| **Job** | [`sync-bumpversion`](https://github.com/kdeldycke/click-extra/blob/1dd31577e87f2a5d2837dcd1db5f96f05672666f/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/1dd31577e87f2a5d2837dcd1db5f96f05672666f/.github/workflows/autofix.yaml) |
| **Run** | [#2776.1](https://github.com/kdeldycke/click-extra/actions/runs/26420224795) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.21.0`