### PR TITLE
Format Markdown

### DIFF
--- a/docs/colorize.md
+++ b/docs/colorize.md
@@ -285,7 +285,6 @@ assert result.output == dedent("""\
 
 ```{admonition} Why plain, linear output?
 :class: tip
-
 A screen reader is not the only consumer that prefers a linear, minimal-width stream over a terminal-wide 2D layout. Command output is also pasted into bug reports, piped into other tools, and read on narrow screens. A layout that imposes a maximal width (full-width tables, box-drawing borders, whitespace-padded columns) wraps awkwardly or [grows a horizontal scrollbar](https://github.com/callowayproject/bump-my-version/pull/23#issuecomment-1602007874) once it leaves the terminal it was sized for, while a stream rendered at the minimal width of its text travels everywhere intact.
 
 This is the same reasoning that keeps Click Extra from routing its help screens through [`rich-click`](https://github.com/ewels/rich-click), a good project integrating [Rich](https://github.com/Textualize/rich) with Click whose [help is laid out in a table](https://github.com/ewels/rich-click) spanning the whole terminal width. `--accessible` carries that preference from help screens to colors and tables. The two are not mutually exclusive, though: nothing stops you from using `rich-click` and Click Extra together and taking the best of both.

--- a/docs/context.md
+++ b/docs/context.md
@@ -47,7 +47,7 @@ The table below lists every entry Click Extra writes, the option that triggers i
 | `context.TABLE_FORMAT`    | `click_extra.table_format`    | `--table-format` callback (`@table_format_option`)         | `TableFormat`                                                          |
 | `context.SORT_BY`         | `click_extra.sort_by`         | `--sort-by` callback (`@sort_by_option`)                   | `tuple[str, ...]` — column IDs in priority order                       |
 | `context.THEME`           | `click_extra.theme.active`    | `--theme` callback (always present on `@command`)          | `HelpExtraTheme` — palette picked for this invocation                  |
-| `context.ZERO_EXIT`       | `click_extra.zero_exit`       | `-0` / `--zero-exit` callback (`@zero_exit_option`)         | `bool` — `True` to always exit 0 *(write-only)*                        |
+| `context.ZERO_EXIT`       | `click_extra.zero_exit`       | `-0` / `--zero-exit` callback (`@zero_exit_option`)        | `bool` — `True` to always exit 0 *(write-only)*                        |
 
 ## Worked examples
 

--- a/docs/man-page.md
+++ b/docs/man-page.md
@@ -158,10 +158,10 @@ The `FILES` section documents the files a program reads. Click Extra's `--config
 
 The `EXIT STATUS` section documents the process return codes. Click Extra inherits Click's conventional scheme:
 
-| Code | Meaning                                                                                   |
-| ---- | ----------------------------------------------------------------------------------------- |
-| `0`  | Success.                                                                                  |
-| `1`  | A runtime error, or an aborted prompt (`Ctrl-C`, a declined confirmation).                |
+| Code | Meaning                                                                                          |
+| ---- | ------------------------------------------------------------------------------------------------ |
+| `0`  | Success.                                                                                         |
+| `1`  | A runtime error, or an aborted prompt (`Ctrl-C`, a declined confirmation).                       |
 | `2`  | A usage error: unknown option, invalid value, missing operand, or an unparsable `--config` file. |
 
 A successful run returns `0`:

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -44,7 +44,7 @@ Now invocations of the `weather` CLI pick up the light theme without passing `--
 | [`dracula`](#dracula)               | 24-bit RGB           | High-contrast dark theme with vivid neon accents.                    |
 | [`nord`](#nord)                     | 24-bit RGB           | Cool-toned dark theme built around frost-blue and aurora accents.    |
 | [`monokai`](#monokai)               | 24-bit RGB           | Classic dark theme with high-saturation magenta and lime accents.    |
-| [`manpage`](#manpage)               | None (monochrome)    | Bold literals, italic replaceable, no color. Shadows a man page.    |
+| [`manpage`](#manpage)               | None (monochrome)    | Bold literals, italic replaceable, no color. Shadows a man page.     |
 
 Each row is keyed by the `--theme` choice value; access the instance via `BUILTIN_THEMES["<name>"]` (e.g. `BUILTIN_THEMES["dark"]`). Click any name to jump to that theme's [palette listing](#palettes) below.
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -217,25 +217,25 @@ Notice in the example above how the `@command()` decorator from Cloup is used wi
 
 Click Extra provides these additional, pre-configured options decorators you can use standalone. Some of them are included by default in the {py:func}`@extra_command and @extra_group <click_extra.commands.default_extra_params>` decorators (see the last column):
 
-| Decorator                                                          | Specification                             | Default |
-| ------------------------------------------------------------------ | ----------------------------------------- | ------- |
-| [`@timer_option`](execution.md#timer)                              | `--time / --no-time`                      | ✅      |
-| [`@accessible_option`](colorize.md#accessible-flag)                | `--accessible`                            | ✅      |
-| [`@color_option`](colorize.md#color-no-color-flag)                 | `--color, --ansi / --no-color, --no-ansi` | ✅      |
-| [`@theme_option`](theme.md)                                        | `--theme`                                 | ✅      |
-| [`@config_option`](config.md#standalone-option)                    | `--config CONFIG_PATH`                    | ✅      |
-| [`@no_config_option`](config.md#)                                  | `--no-config`                             | ✅      |
+| Decorator                                                             | Specification                             | Default |
+| --------------------------------------------------------------------- | ----------------------------------------- | ------- |
+| [`@timer_option`](execution.md#timer)                                 | `--time / --no-time`                      | ✅      |
+| [`@accessible_option`](colorize.md#accessible-flag)                   | `--accessible`                            | ✅      |
+| [`@color_option`](colorize.md#color-no-color-flag)                    | `--color, --ansi / --no-color, --no-ansi` | ✅      |
+| [`@theme_option`](theme.md)                                           | `--theme`                                 | ✅      |
+| [`@config_option`](config.md#standalone-option)                       | `--config CONFIG_PATH`                    | ✅      |
+| [`@no_config_option`](config.md#)                                     | `--no-config`                             | ✅      |
 | [`@validate_config_option`](config.md#validating-configuration-files) | `--validate-config FILE`                  | ✅      |
-| [`@show_params_option`](parameters.md#show-params-option)          | `--show-params`                           | ✅      |
-| [`@table_format_option`](table.md)                                 | `--table-format FORMAT`                   | ✅      |
-| [`@verbosity_option`](logging.md#colored-verbosity)                | `--verbosity LEVEL`                       | ✅      |
-| {py:class}`@verbose_option <click_extra.logging.VerboseOption>`    | `-v, --verbose`                           | ✅      |
-| [`@man_option`](man-page.md#generating-man-pages)                  | `--man`                                   | ✅      |
-| [`@version_option`](version.md)                                    | `--version`                               | ✅      |
-| {py:class}`@help_option <click_extra.colorize.HelpExtraFormatter>` | `-h, --help`                              | ✅      |
-| [`@jobs_option`](execution.md#parallel-jobs)                       | `--jobs INTEGER`                          | ❌      |
-| {py:mod}`@telemetry_option <click_extra.telemetry>`                | `--telemetry / --no-telemetry`            | ❌      |
-| [`@zero_exit_option`](execution.md#zero-exit-code)                 | `-0, --zero-exit`                         | ❌      |
+| [`@show_params_option`](parameters.md#show-params-option)             | `--show-params`                           | ✅      |
+| [`@table_format_option`](table.md)                                    | `--table-format FORMAT`                   | ✅      |
+| [`@verbosity_option`](logging.md#colored-verbosity)                   | `--verbosity LEVEL`                       | ✅      |
+| {py:class}`@verbose_option <click_extra.logging.VerboseOption>`       | `-v, --verbose`                           | ✅      |
+| [`@man_option`](man-page.md#generating-man-pages)                     | `--man`                                   | ✅      |
+| [`@version_option`](version.md)                                       | `--version`                               | ✅      |
+| {py:class}`@help_option <click_extra.colorize.HelpExtraFormatter>`    | `-h, --help`                              | ✅      |
+| [`@jobs_option`](execution.md#parallel-jobs)                          | `--jobs INTEGER`                          | ❌      |
+| {py:mod}`@telemetry_option <click_extra.telemetry>`                   | `--telemetry / --no-telemetry`            | ❌      |
+| [`@zero_exit_option`](execution.md#zero-exit-code)                    | `-0, --zero-exit`                         | ❌      |
 
 ```{note}
 Because single-letter options are a scarce resource, Click Extra does not impose them on you. All the options above are specified with their long names only. You can always customize them to add a short name if you wish.


### PR DESCRIPTION
### Description

Auto-formats Markdown files with [mdformat](https://github.com/hukkin/mdformat) and its plugins. See the [`format-markdown` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize Markdown formatting via [`[tool.mdformat]`](https://mdformat.readthedocs.io/en/stable/users/configuration_file.html) in your `pyproject.toml`, or via a native `.mdformat.toml` file.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`00ebf94f`](https://github.com/kdeldycke/click-extra/commit/00ebf94f8bc73ddc5218260c5d1f78c534f41d61) |
| **Job** | [`format-markdown`](https://github.com/kdeldycke/click-extra/blob/00ebf94f8bc73ddc5218260c5d1f78c534f41d61/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/00ebf94f8bc73ddc5218260c5d1f78c534f41d61/.github/workflows/autofix.yaml) |
| **Run** | [#2808.1](https://github.com/kdeldycke/click-extra/actions/runs/27114178506) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.24.0`