### PR TITLE
Format Python

### DIFF
--- a/click_extra/sphinx/manpages.py
+++ b/click_extra/sphinx/manpages.py
@@ -33,9 +33,9 @@ Configuration shape::
 
     click_extra_manpages = [
         {
-            "script": "meta_package_manager.cli:mpm",   # required
-            "prog_name": "mpm",                          # optional, see below
-            "output_dir": "man",                         # optional, defaults to "man"
+            "script": "meta_package_manager.cli:mpm",  # required
+            "prog_name": "mpm",  # optional, see below
+            "output_dir": "man",  # optional, defaults to "man"
         },
     ]
 


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`5bf8c506`](https://github.com/kdeldycke/click-extra/commit/5bf8c5065605210dae12a9614bbfe440a044b77a) |
| **Job** | [`format-python`](https://github.com/kdeldycke/click-extra/blob/5bf8c5065605210dae12a9614bbfe440a044b77a/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/5bf8c5065605210dae12a9614bbfe440a044b77a/.github/workflows/autofix.yaml) |
| **Run** | [#2815.1](https://github.com/kdeldycke/click-extra/actions/runs/27286452704) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.24.0`