### PR TITLE
Format Python

### DIFF
--- a/click_extra/man_page.py
+++ b/click_extra/man_page.py
@@ -243,8 +243,7 @@ def _emit_help(text: str) -> list[str]:
             post = post.strip("\n")
             if post:
                 out.append(".nf")
-                for line in post.splitlines():
-                    out.append(_render_inline(line))
+                out.extend(_render_inline(line) for line in post.splitlines())
                 out.append(".fi")
     return out
 
@@ -405,9 +404,7 @@ class ManPage:
         # reST literals show up as bold instead of leaking through as
         # raw backticks rendered as quotes by mandoc.
         lines.append(
-            f"{name} \\- {_render_inline(self.short_help)}"
-            if self.short_help
-            else name
+            f"{name} \\- {_render_inline(self.short_help)}" if self.short_help else name
         )
 
         lines.append(".SH SYNOPSIS")

--- a/click_extra/version.py
+++ b/click_extra/version.py
@@ -708,9 +708,7 @@ class ExtraVersionOption(ExtraOption):
 
         # The given name didn't match an installed distribution. Try
         # resolving it as an import (top-level module) name.
-        distributions = metadata.packages_distributions().get(
-            self.package_name, []
-        )
+        distributions = metadata.packages_distributions().get(self.package_name, [])
         if len(distributions) == 1:
             return metadata.version(distributions[0])
         if len(distributions) > 1:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -366,7 +366,7 @@ def test_package_version_unknown_returns_none(monkeypatch):
         raise _metadata.PackageNotFoundError(name)
 
     monkeypatch.setattr(_metadata, "version", fake_version)
-    monkeypatch.setattr(_metadata, "packages_distributions", lambda: {})
+    monkeypatch.setattr(_metadata, "packages_distributions", dict)
 
     opt = ExtraVersionOption(["--version"], package_name="nonexistent")
     assert opt.package_version is None


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`0a7e49fe`](https://github.com/kdeldycke/click-extra/commit/0a7e49fee20ffa91ed565e416294df5537114a1f) |
| **Job** | [`format-python`](https://github.com/kdeldycke/click-extra/blob/0a7e49fee20ffa91ed565e416294df5537114a1f/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/0a7e49fee20ffa91ed565e416294df5537114a1f/.github/workflows/autofix.yaml) |
| **Run** | [#2821.1](https://github.com/kdeldycke/click-extra/actions/runs/27341539144) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.24.0`