### PR TITLE
Format Markdown

### DIFF
--- a/docs/sphinx.md
+++ b/docs/sphinx.md
@@ -676,15 +676,15 @@ Which renders as:
 
 #### Tree options
 
-| Option              | Description                                                                                                | Default                  |
-| ------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------ |
-| `:max-depth:`       | Maximum recursion depth into nested groups.                                                                | `10`                     |
-| `:heading-offset:`  | Shift all generated headings down by N levels (set to `0` when the directive is the document's top entry). | `1`                      |
-| `:anchor-prefix:`   | Slug prefix for every generated anchor.                                                                    | Slug of the CLI name.    |
-| `:label-prefix:`    | Display prefix for the command labels in the table and headings.                                           | The CLI name.            |
-| `:root-label:`      | Heading text for the root `--help` block.                                                                  | `"Help screen"`          |
-| `:no-table:`        | Skip the summary table.                                                                                    | Table is rendered.       |
-| `:no-root:`         | Skip the root `--help` block.                                                                              | Root block is rendered.  |
+| Option             | Description                                                                                                | Default                 |
+| ------------------ | ---------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `:max-depth:`      | Maximum recursion depth into nested groups.                                                                | `10`                    |
+| `:heading-offset:` | Shift all generated headings down by N levels (set to `0` when the directive is the document's top entry). | `1`                     |
+| `:anchor-prefix:`  | Slug prefix for every generated anchor.                                                                    | Slug of the CLI name.   |
+| `:label-prefix:`   | Display prefix for the command labels in the table and headings.                                           | The CLI name.           |
+| `:root-label:`     | Heading text for the root `--help` block.                                                                  | `"Help screen"`         |
+| `:no-table:`       | Skip the summary table.                                                                                    | Table is rendered.      |
+| `:no-root:`        | Skip the root `--help` block.                                                                              | Root block is rendered. |
 
 #### Inline import in the directive body
 


### PR DESCRIPTION
### Description

Auto-formats Markdown files with [mdformat](https://github.com/hukkin/mdformat) and its plugins. See the [`format-markdown` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize Markdown formatting via [`[tool.mdformat]`](https://mdformat.readthedocs.io/en/stable/users/configuration_file.html) in your `pyproject.toml`, or via a native `.mdformat.toml` file.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`270669e2`](https://github.com/kdeldycke/click-extra/commit/270669e2f82bf058992ca172f65c9ceb516433d5) |
| **Job** | [`format-markdown`](https://github.com/kdeldycke/click-extra/blob/270669e2f82bf058992ca172f65c9ceb516433d5/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/270669e2f82bf058992ca172f65c9ceb516433d5/.github/workflows/autofix.yaml) |
| **Run** | [#2829.1](https://github.com/kdeldycke/click-extra/actions/runs/27460950007) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.25.1`