### PR TITLE
Format Python

### DIFF
--- a/tests/sphinx/test_sphinx_click_tree.py
+++ b/tests/sphinx/test_sphinx_click_tree.py
@@ -127,7 +127,7 @@ def test_click_tree_max_depth_truncates_walk(sphinx_app_myst):
     # surfaces a row for `jars` in its own subcommand listing, so we only
     # assert on the directive-generated anchor.
     assert 'href="#kitchen-pantry-jars"' not in html
-    assert "id=\"kitchen-pantry-jars\"" not in html
+    assert 'id="kitchen-pantry-jars"' not in html
 
 
 def test_click_tree_label_and_anchor_prefix_override(sphinx_app_myst):


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`3719ff4d`](https://github.com/kdeldycke/click-extra/commit/3719ff4d8392f709cc87ee376a586a8efef33c7e) |
| **Job** | [`format-python`](https://github.com/kdeldycke/click-extra/blob/3719ff4d8392f709cc87ee376a586a8efef33c7e/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/3719ff4d8392f709cc87ee376a586a8efef33c7e/.github/workflows/autofix.yaml) |
| **Run** | [#2831.1](https://github.com/kdeldycke/click-extra/actions/runs/27461700978) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.25.1`