### PR TITLE
Format Python

### DIFF
--- a/docs/spinner.md
+++ b/docs/spinner.md
@@ -208,6 +208,7 @@ Read the elapsed time any moment from the `elapsed_time` property, which freezes
 from click_extra import Spinner, command, pass_context
 from click_extra.context import PROGRESS
 
+
 @command
 @pass_context
 def harvest(ctx):


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`cf18e433`](https://github.com/kdeldycke/click-extra/commit/cf18e4338c9b268df6f36c104618fc093c6e9d9f) |
| **Job** | [`format-python`](https://github.com/kdeldycke/click-extra/blob/cf18e4338c9b268df6f36c104618fc093c6e9d9f/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/cf18e4338c9b268df6f36c104618fc093c6e9d9f/.github/workflows/autofix.yaml) |
| **Run** | [#2870.1](https://github.com/kdeldycke/click-extra/actions/runs/27831037410) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.27.0`