### PR TITLE
Format Markdown

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -33,22 +33,22 @@ You may also reach the same entry through the literal string (`ctx.meta["click_e
 
 The table below lists every entry Click Extra writes, the option that triggers it, and the value's shape. Entries marked *write-only* are not read back internally: they exist so your code can inspect what the user picked.
 
-| Constant                  | String key                    | Set by                                                     | Value                                                                  |
-| ------------------------- | ----------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------- |
-| `context.RAW_ARGS`        | `click_extra.raw_args`        | `Command.make_context` (always, on `@command` group)  | `list[str]`: pre-parsed `argv` slice fed to the current command       |
-| `context.CONF_SOURCE`     | `click_extra.conf_source`     | `ConfigOption.load_conf` (`@config_option`)                | `pathlib.Path \| URL \| None`: file the configuration was loaded from |
-| `context.CONF_FULL`       | `click_extra.conf_full`       | `ConfigOption.load_conf` (`@config_option`)                | `dict \| None`: full parsed configuration document                    |
-| `context.TOOL_CONFIG`     | `click_extra.tool_config`     | `ConfigOption._apply_config_schema` (with `config_schema`) | The deserialised app section (also reachable via `get_tool_config()`)  |
-| `context.VERBOSITY_LEVEL` | `click_extra.verbosity_level` | `--verbosity` / `--verbose` callbacks (reconciled)         | `LogLevel`: the highest level any verbosity option picked             |
-| `context.VERBOSITY`       | `click_extra.verbosity`       | `--verbosity` callback                                     | `LogLevel`: raw value of `--verbosity LEVEL` *(write-only)*           |
-| `context.VERBOSE`         | `click_extra.verbose`         | `--verbose` / `-v` callback                                | `int`: repetition count *(write-only)*                                |
-| `context.START_TIME`      | `click_extra.start_time`      | `--time` callback (`@timer_option`)                        | `float`: `time.perf_counter()` snapshot                               |
-| `context.JOBS`            | `click_extra.jobs`            | `--jobs` callback (`@jobs_option`)                         | `int`: effective parallel job count (clamped to >= 1)                 |
-| `context.PROGRESS`        | `click_extra.progress`        | `ProgressOption.set_progress` (always present on `@command`) | `bool`: `True` when progress spinners may display                   |
-| `context.TABLE_FORMAT`    | `click_extra.table_format`    | `--table-format` callback (`@table_format_option`)         | `TableFormat`                                                          |
-| `context.SORT_BY`         | `click_extra.sort_by`         | `--sort-by` callback (`@sort_by_option`)                   | `tuple[str, ...]`: column IDs in priority order                       |
-| `context.THEME`           | `click_extra.theme.active`    | `--theme` callback (always present on `@command`)          | `HelpTheme`: palette picked for this invocation                  |
-| `context.ZERO_EXIT`       | `click_extra.zero_exit`       | `-0` / `--zero-exit` callback (`@zero_exit_option`)        | `bool`: `True` to always exit 0 *(write-only)*                        |
+| Constant                  | String key                    | Set by                                                       | Value                                                                 |
+| ------------------------- | ----------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------- |
+| `context.RAW_ARGS`        | `click_extra.raw_args`        | `Command.make_context` (always, on `@command` group)         | `list[str]`: pre-parsed `argv` slice fed to the current command       |
+| `context.CONF_SOURCE`     | `click_extra.conf_source`     | `ConfigOption.load_conf` (`@config_option`)                  | `pathlib.Path \| URL \| None`: file the configuration was loaded from |
+| `context.CONF_FULL`       | `click_extra.conf_full`       | `ConfigOption.load_conf` (`@config_option`)                  | `dict \| None`: full parsed configuration document                    |
+| `context.TOOL_CONFIG`     | `click_extra.tool_config`     | `ConfigOption._apply_config_schema` (with `config_schema`)   | The deserialised app section (also reachable via `get_tool_config()`) |
+| `context.VERBOSITY_LEVEL` | `click_extra.verbosity_level` | `--verbosity` / `--verbose` callbacks (reconciled)           | `LogLevel`: the highest level any verbosity option picked             |
+| `context.VERBOSITY`       | `click_extra.verbosity`       | `--verbosity` callback                                       | `LogLevel`: raw value of `--verbosity LEVEL` *(write-only)*           |
+| `context.VERBOSE`         | `click_extra.verbose`         | `--verbose` / `-v` callback                                  | `int`: repetition count *(write-only)*                                |
+| `context.START_TIME`      | `click_extra.start_time`      | `--time` callback (`@timer_option`)                          | `float`: `time.perf_counter()` snapshot                               |
+| `context.JOBS`            | `click_extra.jobs`            | `--jobs` callback (`@jobs_option`)                           | `int`: effective parallel job count (clamped to >= 1)                 |
+| `context.PROGRESS`        | `click_extra.progress`        | `ProgressOption.set_progress` (always present on `@command`) | `bool`: `True` when progress spinners may display                     |
+| `context.TABLE_FORMAT`    | `click_extra.table_format`    | `--table-format` callback (`@table_format_option`)           | `TableFormat`                                                         |
+| `context.SORT_BY`         | `click_extra.sort_by`         | `--sort-by` callback (`@sort_by_option`)                     | `tuple[str, ...]`: column IDs in priority order                       |
+| `context.THEME`           | `click_extra.theme.active`    | `--theme` callback (always present on `@command`)            | `HelpTheme`: palette picked for this invocation                       |
+| `context.ZERO_EXIT`       | `click_extra.zero_exit`       | `-0` / `--zero-exit` callback (`@zero_exit_option`)          | `bool`: `True` to always exit 0 *(write-only)*                        |
 
 ## Worked examples
 

--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -133,27 +133,27 @@ c()
 
 Every default option ships with a matching decorator built via `decorator_factory`:
 
-| Decorator                | Wraps                                                          |
-| ------------------------ | -------------------------------------------------------------- |
+| Decorator                | Wraps                                               |
+| ------------------------ | --------------------------------------------------- |
 | `command`                | `cloup.command(cls=Command, params=default_params)` |
 | `group`                  | `cloup.group(cls=Group, params=default_params)`     |
-| `lazy_group`             | `group(cls=LazyGroup)`                                         |
-| `option`                 | `cloup.option(cls=Option)`                                     |
-| `argument`               | `cloup.argument(cls=Argument)`                                 |
-| `help_option`            | `click.decorators.help_option(*DEFAULT_HELP_NAMES)`            |
-| `version_option`         | `option(cls=VersionOption)`                               |
-| `color_option`           | `option(cls=ColorOption)`                                      |
-| `config_option`          | `option(cls=ConfigOption)`                                     |
-| `no_config_option`       | `option(cls=NoConfigOption)`                                   |
-| `validate_config_option` | `option(cls=ValidateConfigOption)`                             |
-| `jobs_option`            | `option(cls=JobsOption)`                                       |
-| `show_params_option`     | `option(cls=ShowParamsOption)`                                 |
-| `table_format_option`    | `option(cls=TableFormatOption)`                                |
-| `telemetry_option`       | `option(cls=TelemetryOption)`                                  |
-| `theme_option`           | `option(cls=ThemeOption)`                                      |
-| `timer_option`           | `option(cls=TimerOption)`                                      |
-| `verbose_option`         | `option(cls=VerboseOption)`                                    |
-| `verbosity_option`       | `option(cls=VerbosityOption)`                                  |
+| `lazy_group`             | `group(cls=LazyGroup)`                              |
+| `option`                 | `cloup.option(cls=Option)`                          |
+| `argument`               | `cloup.argument(cls=Argument)`                      |
+| `help_option`            | `click.decorators.help_option(*DEFAULT_HELP_NAMES)` |
+| `version_option`         | `option(cls=VersionOption)`                         |
+| `color_option`           | `option(cls=ColorOption)`                           |
+| `config_option`          | `option(cls=ConfigOption)`                          |
+| `no_config_option`       | `option(cls=NoConfigOption)`                        |
+| `validate_config_option` | `option(cls=ValidateConfigOption)`                  |
+| `jobs_option`            | `option(cls=JobsOption)`                            |
+| `show_params_option`     | `option(cls=ShowParamsOption)`                      |
+| `table_format_option`    | `option(cls=TableFormatOption)`                     |
+| `telemetry_option`       | `option(cls=TelemetryOption)`                       |
+| `theme_option`           | `option(cls=ThemeOption)`                           |
+| `timer_option`           | `option(cls=TimerOption)`                           |
+| `verbose_option`         | `option(cls=VerboseOption)`                         |
+| `verbosity_option`       | `option(cls=VerbosityOption)`                       |
 
 Every entry in this list is an `allow_missing_parenthesis`-wrapped factory, so `@theme_option` and `@theme_option()` are both legal, and `@theme_option(default="light")` overrides the default while keeping the click-extra subclass guarantee.
 

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -31,14 +31,14 @@ $ clishot "my-cli --help"
 
 The wider landscape splits by need: a regenerable static image, an animated demo, or a quick hand-made shot.
 
-| Tool | Output | Runs your command? | Install | Diffable source | Best for |
-| :--- | :--- | :--- | :--- | :--- | :--- |
-| [`rich-codex`](https://ewels.github.io/rich-codex/) | SVG, PNG | Yes | `uvx` (Python) | Yes | Automated, regenerable shots |
-| [`freeze`](https://github.com/charmbracelet/freeze) | SVG, PNG, WebP | Yes (`--execute`) | Go binary | Yes | Static shots without a Python tool |
-| [`vhs`](https://github.com/charmbracelet/vhs) | GIF, MP4, WebM | Scripted `.tape` | Go binary | No | Reproducible animated demos |
-| [`asciinema`](https://asciinema.org) + [`agg`](https://github.com/asciinema/agg) | GIF, animated SVG | Yes (records) | Rust, npm | Yes (`.cast`) | Authentic session recordings |
-| [Rich export](https://rich.readthedocs.io/en/stable/console.html), [`ansitoimg`](https://github.com/FHPythonUtils/AnsiToImg) | SVG, HTML, PNG | No (converts text) | `uvx` (Python) | Yes (SVG) | Output you already captured |
-| [ray.so](https://ray.so), [Carbon](https://carbon.now.sh), [chalk.ist](https://chalk.ist) | PNG, SVG | No (paste) | Web | No | One-off marketing shots |
+| Tool                                                                                                                         | Output            | Runs your command? | Install        | Diffable source | Best for                           |
+| :--------------------------------------------------------------------------------------------------------------------------- | :---------------- | :----------------- | :------------- | :-------------- | :--------------------------------- |
+| [`rich-codex`](https://ewels.github.io/rich-codex/)                                                                          | SVG, PNG          | Yes                | `uvx` (Python) | Yes             | Automated, regenerable shots       |
+| [`freeze`](https://github.com/charmbracelet/freeze)                                                                          | SVG, PNG, WebP    | Yes (`--execute`)  | Go binary      | Yes             | Static shots without a Python tool |
+| [`vhs`](https://github.com/charmbracelet/vhs)                                                                                | GIF, MP4, WebM    | Scripted `.tape`   | Go binary      | No              | Reproducible animated demos        |
+| [`asciinema`](https://asciinema.org) + [`agg`](https://github.com/asciinema/agg)                                             | GIF, animated SVG | Yes (records)      | Rust, npm      | Yes (`.cast`)   | Authentic session recordings       |
+| [Rich export](https://rich.readthedocs.io/en/stable/console.html), [`ansitoimg`](https://github.com/FHPythonUtils/AnsiToImg) | SVG, HTML, PNG    | No (converts text) | `uvx` (Python) | Yes (SVG)       | Output you already captured        |
+| [ray.so](https://ray.so), [Carbon](https://carbon.now.sh), [chalk.ist](https://chalk.ist)                                    | PNG, SVG          | No (paste)         | Web            | No              | One-off marketing shots            |
 
 A few specifics the table compresses: [`freeze`](https://github.com/charmbracelet/freeze) is a single Go binary whose `--execute "my-cli --help"` captures real ANSI output with no Python involved. [`vhs`](https://github.com/charmbracelet/vhs) replays a `.tape` script rather than recording you, which makes its animations deterministic and re-runnable in CI. [`asciinema`](https://asciinema.org) records a genuine session into a plain-text `.cast` file that diffs in git, then [`agg`](https://github.com/asciinema/agg) renders it to a GIF or [`svg-term-cli`](https://github.com/marionebl/svg-term-cli) to an animated SVG. Rich's `Console(record=True).export_svg()` is the zero-dependency engine that both `rich-codex` and `ansitoimg` build on, so reach for it when you already hold the ANSI text and want no capture layer.
 

--- a/docs/sphinx.md
+++ b/docs/sphinx.md
@@ -719,13 +719,13 @@ The rendered output is identical to the kitchen example above: a summary table a
 
 Click Extra also adds five general-purpose Python execution directives, registered under a separate `python` domain (distinct from Sphinx's built-in `py` domain for documenting API objects):
 
-| Directive            | Purpose                                                                                                                                                                                                                               |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `python:source`      | Define and show a Python source block, executed silently. Use it to teach readers what a snippet looks like and to seed imports/variables for follow-up blocks.                                                                       |
-| `python:run`         | Execute a Python block and render its captured `stdout` in a code block. Output language defaults to `text`; override with `:language:` for structured output (`json`, `html`, `yaml`, etc.).                                         |
+| Directive            | Purpose                                                                                                                                                                                                                              |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `python:source`      | Define and show a Python source block, executed silently. Use it to teach readers what a snippet looks like and to seed imports/variables for follow-up blocks.                                                                      |
+| `python:run`         | Execute a Python block and render its captured `stdout` in a code block. Output language defaults to `text`; override with `:language:` for structured output (`json`, `html`, `yaml`, etc.).                                        |
 | `python:render`      | Execute a Python block and parse its captured `stdout` as **live document content** using the host file's parser. Generated tables, headings, admonitions, and cross-references become first-class document nodes, not a code block. |
-| `python:render-myst` | Execute a Python block and parse its captured `stdout` as MyST, regardless of host. Lets a `.rst` document embed MyST-generated content.                                                                                              |
-| `python:render-rst`  | Execute a Python block and parse its captured `stdout` as reST, regardless of host. Lets a `.md` document embed reST-generated content.                                                                                               |
+| `python:render-myst` | Execute a Python block and parse its captured `stdout` as MyST, regardless of host. Lets a `.rst` document embed MyST-generated content.                                                                                             |
+| `python:render-rst`  | Execute a Python block and parse its captured `stdout` as reST, regardless of host. Lets a `.md` document embed reST-generated content.                                                                                              |
 
 These complement the Click directives: `click:run` is for showing simulated CLI sessions; `python:run` is for showing arbitrary Python output; the `python:render*` family is for **inline content generation**, replacing the regenerator-script + marker-region pattern many projects use to keep auto-tables in sync.
 

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -2,7 +2,7 @@
 
 A *test plan* is a declarative list of CLI invocations and the results each one should produce. Click Extra runs the plan against any command or binary as separate subprocesses, checking exit codes and output. It is the black-box, subprocess-level complement to [`CliRunner`](testing.md), which drives a CLI in-process: a test plan never imports the target, so it works just as well against a compiled binary, a shell command, or a CLI written in another language.
 
-```{important}
+````{important}
 Parsing a plan from YAML needs the optional `pyyaml` dependency. Install it with the `yaml` extra:
 
 ​```{code-block} shell-session
@@ -10,7 +10,7 @@ $ pip install click-extra[yaml]
 ​```
 
 The engine itself (building `CLITestCase` objects and running them) has no such requirement: only `parse_test_plan` does.
-```
+````
 
 ## Writing a plan
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -217,27 +217,27 @@ Notice in the example above how the `@command()` decorator from Cloup is used wi
 
 Click Extra provides these additional, pre-configured options decorators you can use standalone. Some of them are included by default in the {py:func}`@command and @group <click_extra.commands.default_params>` decorators (see the last column):
 
-| Decorator                                                             | Specification                             | Default |
-| --------------------------------------------------------------------- | ----------------------------------------- | ------- |
-| [`@timer_option`](execution.md#timer)                                 | `--time / --no-time`                      | ✅      |
-| [`@accessible_option`](colorize.md#accessible-flag)                   | `--accessible`                            | ✅      |
-| [`@color_option`](colorize.md#color-no-color-flag)                    | `--color [auto\|always\|never]`           | ✅      |
-| [`@no_color_option`](colorize.md#color-no-color-flag)                 | `--no-color`                              | ✅      |
-| [`@theme_option`](theme.md)                                           | `--theme`                                 | ✅      |
-| [`@config_option`](config.md#standalone-option)                       | `--config CONFIG_PATH`                    | ✅      |
-| [`@no_config_option`](config.md#)                                     | `--no-config`                             | ✅      |
-| [`@validate_config_option`](config.md#validating-configuration-files) | `--validate-config FILE`                  | ✅      |
-| [`@show_params_option`](parameters.md#show-params-option)             | `--show-params`                           | ✅      |
-| [`@table_format_option`](table.md)                                    | `--table-format FORMAT`                   | ✅      |
-| [`@verbosity_option`](logging.md#colored-verbosity)                   | `--verbosity LEVEL`                       | ✅      |
-| {py:class}`@verbose_option <click_extra.logging.VerboseOption>`       | `-v, --verbose`                           | ✅      |
-| {py:class}`@quiet_option <click_extra.logging.QuietOption>`           | `-q, --quiet`                             | ✅      |
-| [`@man_option`](man-page.md#generating-man-pages)                     | `--man`                                   | ✅      |
-| [`@version_option`](version.md)                                       | `--version`                               | ✅      |
-| {py:class}`@help_option <click_extra.highlight.HelpFormatter>`    | `-h, --help`                              | ✅      |
-| [`@jobs_option`](execution.md#parallel-jobs)                          | `--jobs [auto\|max\|INTEGER]`             | ❌      |
-| {py:mod}`@telemetry_option <click_extra.telemetry>`                   | `--telemetry / --no-telemetry`            | ❌      |
-| [`@zero_exit_option`](execution.md#zero-exit-code)                    | `-0, --zero-exit`                         | ❌      |
+| Decorator                                                             | Specification                   | Default |
+| --------------------------------------------------------------------- | ------------------------------- | ------- |
+| [`@timer_option`](execution.md#timer)                                 | `--time / --no-time`            | ✅      |
+| [`@accessible_option`](colorize.md#accessible-flag)                   | `--accessible`                  | ✅      |
+| [`@color_option`](colorize.md#color-no-color-flag)                    | `--color [auto\|always\|never]` | ✅      |
+| [`@no_color_option`](colorize.md#color-no-color-flag)                 | `--no-color`                    | ✅      |
+| [`@theme_option`](theme.md)                                           | `--theme`                       | ✅      |
+| [`@config_option`](config.md#standalone-option)                       | `--config CONFIG_PATH`          | ✅      |
+| [`@no_config_option`](config.md#)                                     | `--no-config`                   | ✅      |
+| [`@validate_config_option`](config.md#validating-configuration-files) | `--validate-config FILE`        | ✅      |
+| [`@show_params_option`](parameters.md#show-params-option)             | `--show-params`                 | ✅      |
+| [`@table_format_option`](table.md)                                    | `--table-format FORMAT`         | ✅      |
+| [`@verbosity_option`](logging.md#colored-verbosity)                   | `--verbosity LEVEL`             | ✅      |
+| {py:class}`@verbose_option <click_extra.logging.VerboseOption>`       | `-v, --verbose`                 | ✅      |
+| {py:class}`@quiet_option <click_extra.logging.QuietOption>`           | `-q, --quiet`                   | ✅      |
+| [`@man_option`](man-page.md#generating-man-pages)                     | `--man`                         | ✅      |
+| [`@version_option`](version.md)                                       | `--version`                     | ✅      |
+| {py:class}`@help_option <click_extra.highlight.HelpFormatter>`        | `-h, --help`                    | ✅      |
+| [`@jobs_option`](execution.md#parallel-jobs)                          | `--jobs [auto\|max\|INTEGER]`   | ❌      |
+| {py:mod}`@telemetry_option <click_extra.telemetry>`                   | `--telemetry / --no-telemetry`  | ❌      |
+| [`@zero_exit_option`](execution.md#zero-exit-code)                    | `-0, --zero-exit`               | ❌      |
 
 ```{note}
 Because single-letter options are a scarce resource, Click Extra does not impose them on you. All the options above are specified with their long names only. You can always customize them to add a short name if you wish.

--- a/docs/version.md
+++ b/docs/version.md
@@ -62,8 +62,8 @@ Click Extra uses [modern format string syntax](https://docs.python.org/3/library
 
 You can customize the message template with the following variables:
 
-| Variable                                                                              | Description                                                                                                                                                                            |
-| ------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Variable                                                                         | Description                                                                                                                                                                            |
+| -------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | {py:attr}`{module} <click_extra.version.VersionOption.module>`                   | The [module object](https://docs.python.org/3/glossary.html#term-module) in which the command is implemented.                                                                          |
 | {py:attr}`{module_name} <click_extra.version.VersionOption.module_name>`         | The [`__name__` of the module](https://docs.python.org/3/reference/datamodel.html#module.__name__) in which the command is implemented.                                                |
 | {py:attr}`{module_file} <click_extra.version.VersionOption.module_file>`         | The [full path of the file](https://docs.python.org/3/reference/datamodel.html#module.__file__) in which the command is implemented.                                                   |
@@ -81,8 +81,8 @@ You can customize the message template with the following variables:
 | {py:attr}`{git_date} <click_extra.version.VersionOption.git_date>`               | The commit date of the current `HEAD` in ISO format (`YYYY-MM-DD HH:MM:SS +ZZZZ`), or `None` if not in a Git repository or Git is not available.                                       |
 | {py:attr}`{git_tag} <click_extra.version.VersionOption.git_tag>`                 | The Git tag pointing at `HEAD`, or `None` if `HEAD` is not at a tagged commit.                                                                                                         |
 | {py:attr}`{git_tag_sha} <click_extra.version.VersionOption.git_tag_sha>`         | The full commit SHA that the current tag points at, or `None` if `HEAD` is not at a tagged commit.                                                                                     |
-| {py:attr}`{git_distance} <click_extra.version.VersionOption.git_distance>`       | The number of commits since the most recent tag, or `None` if no tag is reachable or Git is not available.                                                                            |
-| {py:attr}`{git_dirty} <click_extra.version.VersionOption.git_dirty>`             | The work-tree state: `dirty` for uncommitted changes, `clean` otherwise, or `None` if not in a Git repository or Git is not available.                                                |
+| {py:attr}`{git_distance} <click_extra.version.VersionOption.git_distance>`       | The number of commits since the most recent tag, or `None` if no tag is reachable or Git is not available.                                                                             |
+| {py:attr}`{git_dirty} <click_extra.version.VersionOption.git_dirty>`             | The work-tree state: `dirty` for uncommitted changes, `clean` otherwise, or `None` if not in a Git repository or Git is not available.                                                 |
 | {py:attr}`{prog_name} <click_extra.version.VersionOption.prog_name>`             | The display name of the program. Defaults to Click's `info_name`, but can be [overridden via `prog_name` on the command decorator](commands.md#version-fields).                        |
 | {py:attr}`{env_info} <click_extra.version.VersionOption.env_info>`               | The [environment information](https://boltons.readthedocs.io/en/latest/ecoutils.html#boltons.ecoutils.get_profile) in JSON.                                                            |
 
@@ -346,14 +346,14 @@ All `git_*` template fields support pre-baking. If the CLI module defines a `__<
 
 The supported dunders are:
 
-| Dunder variable      | Template field     | Subprocess fallback                               |
-| -------------------- | ------------------ | ------------------------------------------------- |
-| `__git_branch__`     | `{git_branch}`     | `git rev-parse --abbrev-ref HEAD`                 |
-| `__git_long_hash__`  | `{git_long_hash}`  | `git rev-parse HEAD`                              |
-| `__git_short_hash__` | `{git_short_hash}` | `git rev-parse --short HEAD`                      |
-| `__git_date__`       | `{git_date}`       | `git show -s --format=%ci HEAD`                   |
-| `__git_tag__`        | `{git_tag}`        | `git describe --tags --exact-match HEAD`          |
-| `__git_tag_sha__`    | `{git_tag_sha}`    | `git rev-list -1 <tag>` (if `{git_tag}` resolves) |
+| Dunder variable      | Template field     | Subprocess fallback                                |
+| -------------------- | ------------------ | -------------------------------------------------- |
+| `__git_branch__`     | `{git_branch}`     | `git rev-parse --abbrev-ref HEAD`                  |
+| `__git_long_hash__`  | `{git_long_hash}`  | `git rev-parse HEAD`                               |
+| `__git_short_hash__` | `{git_short_hash}` | `git rev-parse --short HEAD`                       |
+| `__git_date__`       | `{git_date}`       | `git show -s --format=%ci HEAD`                    |
+| `__git_tag__`        | `{git_tag}`        | `git describe --tags --exact-match HEAD`           |
+| `__git_tag_sha__`    | `{git_tag_sha}`    | `git rev-list -1 <tag>` (if `{git_tag}` resolves)  |
 | `__git_distance__`   | `{git_distance}`   | `git describe --tags --long` (commit count parsed) |
 | `__git_dirty__`      | `{git_dirty}`      | `git status --porcelain` (mapped to dirty/clean)   |
 
@@ -447,25 +447,25 @@ The `message_style` parameter sets the style of the message literals (the text a
 
 Fields not listed in `styles` keep the defaults below, taken from {py:attr}`VersionOption.default_styles <click_extra.version.VersionOption.default_styles>`. Fields absent from this table have no style of their own and fall back to `message_style`:
 
-| Field                                | Default style                                      |
-| ------------------------------------ | -------------------------------------------------- |
-| `exec_name`                          | `BUILTIN_THEMES["dark"].invoked_command`{l=python} |
-| `git_branch`                         | `Style(fg="cyan")`{l=python}                       |
-| `git_date`                           | `Style(fg="bright_black")`{l=python}               |
-| `git_distance`                       | `Style(fg="green")`{l=python}                      |
-| `git_dirty`                          | `Style(fg="red")`{l=python}                        |
-| `git_long_hash`                      | `Style(fg="yellow")`{l=python}                     |
-| `git_repo_path`                      | `Style(fg="bright_black")`{l=python}               |
-| `git_short_hash`                     | `Style(fg="yellow")`{l=python}                     |
-| `git_tag`                            | `Style(fg="cyan")`{l=python}                       |
-| `git_tag_sha`                        | `Style(fg="yellow")`{l=python}                     |
-| `module_name`                        | `BUILTIN_THEMES["dark"].invoked_command`{l=python} |
-| `module_version`                     | `Style(fg="green")`{l=python}                      |
-| `package_name`                       | `BUILTIN_THEMES["dark"].invoked_command`{l=python} |
-| `package_version`                    | `Style(fg="green")`{l=python}                      |
-| `prog_name`                          | `BUILTIN_THEMES["dark"].invoked_command`{l=python} |
-| `version`                            | `Style(fg="green")`{l=python}                      |
-| `env_info`                           | `Style(fg="bright_black")`{l=python}               |
+| Field             | Default style                                      |
+| ----------------- | -------------------------------------------------- |
+| `exec_name`       | `BUILTIN_THEMES["dark"].invoked_command`{l=python} |
+| `git_branch`      | `Style(fg="cyan")`{l=python}                       |
+| `git_date`        | `Style(fg="bright_black")`{l=python}               |
+| `git_distance`    | `Style(fg="green")`{l=python}                      |
+| `git_dirty`       | `Style(fg="red")`{l=python}                        |
+| `git_long_hash`   | `Style(fg="yellow")`{l=python}                     |
+| `git_repo_path`   | `Style(fg="bright_black")`{l=python}               |
+| `git_short_hash`  | `Style(fg="yellow")`{l=python}                     |
+| `git_tag`         | `Style(fg="cyan")`{l=python}                       |
+| `git_tag_sha`     | `Style(fg="yellow")`{l=python}                     |
+| `module_name`     | `BUILTIN_THEMES["dark"].invoked_command`{l=python} |
+| `module_version`  | `Style(fg="green")`{l=python}                      |
+| `package_name`    | `BUILTIN_THEMES["dark"].invoked_command`{l=python} |
+| `package_version` | `Style(fg="green")`{l=python}                      |
+| `prog_name`       | `BUILTIN_THEMES["dark"].invoked_command`{l=python} |
+| `version`         | `Style(fg="green")`{l=python}                      |
+| `env_info`        | `Style(fg="bright_black")`{l=python}               |
 
 The remaining fields (`module`, `module_file`, `author`, `license`) have no default style and fall back to `message_style`.
 


### PR DESCRIPTION
### Description

Auto-formats Markdown files with [mdformat](https://github.com/hukkin/mdformat) and its plugins. See the [`format-markdown` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize Markdown formatting via [`[tool.mdformat]`](https://mdformat.readthedocs.io/en/stable/users/configuration_file.html) in your `pyproject.toml`, or via a native `.mdformat.toml` file.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`d5291345`](https://github.com/kdeldycke/click-extra/commit/d5291345239cf0501963be14831060000753b3f9) |
| **Job** | [`format-markdown`](https://github.com/kdeldycke/click-extra/blob/d5291345239cf0501963be14831060000753b3f9/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/d5291345239cf0501963be14831060000753b3f9/.github/workflows/autofix.yaml) |
| **Run** | [#2914.1](https://github.com/kdeldycke/click-extra/actions/runs/27931410067) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.28.1`