### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -577,7 +577,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1029,7 +1029,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1040,9 +1040,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-06-14`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [pytest](https://pypi.org/project/pytest/) | [`9.0.3` → `9.1.0`](https://github.com/pytest-dev/pytest/compare/9.0.3...9.1.0) | 2026-06-13 |

### Release notes

<details>
<summary><code>pytest</code></summary>

#### [`9.1.0`](https://github.com/pytest-dev/pytest/releases/tag/9.1.0)

# pytest 9.1.0 (2026-06-13)

## Removals and backward incompatible breaking changes

- [\#​14533](https://redirect.github.com/pytest-dev/pytest/issues/14533): When using `--doctest-modules`, autouse fixtures with `module`, `package` or `session` scope that are defined inline in Python test modules (not plugins or conftests) will now possibly execute twice.

  If this is undesirable, move the fixture definition to a `conftest.py` file if possible.

  Technical explanation for those interested:
  When using <span class="title-ref">--doctest-modules</span>, pytest possibly collects Python modules twice, once as `pytest.Module` and once as a `DoctestModule` (depending on the configuration).
  Due to improvements in pytest's fixture implementation, if e.g. the `DoctestModule` collects a fixture, it is now visible to it only, and not to the `Module`.
  This means that both need to register the fixtures independently.

## Deprecations (removal in next major release)

- [\#​10819](https://redirect.github.com/pytest-dev/pytest/issues/10819): Added a deprecation warning for class-scoped fixtures defined as instance methods (without `@classmethod`). Such fixtures set attributes on a different instance than the test methods use, leading to unexpected behavior. Use `@classmethod` decorator instead -- by `yastcher`.

  See `10819` and `14011`.

- [\#​12882](https://redirect.github.com/pytest-dev/pytest/issues/12882): Calling `request.getfixturevalue() <pytest.FixtureRequest.getfixturevalue>` during teardown to request a fixture that was not already requested is now deprecated and will become an error in pytest 10.

  See `dynamic-fixture-request-during-teardown` for details.

... [Full release notes](https://github.com/pytest-dev/pytest/releases/tag/9.1.0)

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`e1d610a3`](https://github.com/kdeldycke/click-extra/commit/e1d610a3e66f98d57af8e535dbe9b797b45bec4d) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/click-extra/blob/e1d610a3e66f98d57af8e535dbe9b797b45bec4d/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/e1d610a3e66f98d57af8e535dbe9b797b45bec4d/.github/workflows/autofix.yaml) |
| **Run** | [#2897.1](https://github.com/kdeldycke/click-extra/actions/runs/27897376738) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.28.1`