### PR TITLE
Format Python

### DIFF
--- a/click_extra/parameters.py
+++ b/click_extra/parameters.py
@@ -685,6 +685,7 @@ def render_params_table(
             # re-parse bypasses. See the RAW_ARGS dossier in click_extra.context.
             value, source = param.consume_value(subject_ctx, opts)
             return (None if value is UNSET else value), source
+
     else:
 
         def get_param_value(param):


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`52b58b7e`](https://github.com/kdeldycke/click-extra/commit/52b58b7e0b20a98a72c87cc1cb4c386a76d92697) |
| **Job** | [`format-python`](https://github.com/kdeldycke/click-extra/blob/52b58b7e0b20a98a72c87cc1cb4c386a76d92697/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/52b58b7e0b20a98a72c87cc1cb4c386a76d92697/.github/workflows/autofix.yaml) |
| **Run** | [#2886.1](https://github.com/kdeldycke/click-extra/actions/runs/27868897224) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.28.1`