### PR TITLE
Format Python

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -314,10 +314,12 @@ When you load configuration yourself (or expose a `[tool.<name>]` section consum
 from dataclasses import dataclass
 from click_extra import make_schema_callable
 
+
 @dataclass
 class Forecast:
     city: str = "paris"
     high_c: int = 0
+
 
 load = make_schema_callable(Forecast)
 load({"city": "lyon", "high-c": 21})  # Forecast(city="lyon", high_c=21)


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`ee4d140f`](https://github.com/kdeldycke/click-extra/commit/ee4d140fb761f8e3f6061de4038e7074e29a7f3a) |
| **Job** | [`format-python`](https://github.com/kdeldycke/click-extra/blob/ee4d140fb761f8e3f6061de4038e7074e29a7f3a/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/ee4d140fb761f8e3f6061de4038e7074e29a7f3a/.github/workflows/autofix.yaml) |
| **Run** | [#2906.1](https://github.com/kdeldycke/click-extra/actions/runs/27914156201) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.28.1`