### PR TITLE
Format Python

### DIFF
--- a/click_extra/test_suite.py
+++ b/click_extra/test_suite.py
@@ -251,9 +251,11 @@ class CLITestCase:
             elif field_id == "timeout":
                 # A numeric string or an int is coerced to float; bool is an int
                 # subclass but not a valid duration, so it is rejected below.
-                if isinstance(field_data, str):
-                    field_data = float(field_data)
-                elif isinstance(field_data, int) and not isinstance(field_data, bool):
+                if (
+                    isinstance(field_data, str)
+                    or isinstance(field_data, int)
+                    and not isinstance(field_data, bool)
+                ):
                     field_data = float(field_data)
                 elif field_data is not None and not isinstance(field_data, float):
                     raise ValueError(f"timeout is not a float: {field_data}")

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1607,7 +1607,10 @@ def test_standalone_no_color_rendering(invoke, opt1, opt2, opt3, table_format):
         # A flag with a non-bool flag_value (like NoConfigOption) reports
         # is_bool_flag=False yet still takes no value: it must stay "flag". This is
         # why the classifier keys off is_flag rather than is_bool_flag.
-        (click.Option(["--no-cfg"], is_flag=True, flag_value="x", default=None), "flag"),
+        (
+            click.Option(["--no-cfg"], is_flag=True, flag_value="x", default=None),
+            "flag",
+        ),
         # is_flag=False carrying a flag_value is Click's optional-value option.
         (
             click.Option(["--color"], is_flag=False, flag_value="always", default=None),

--- a/tests/test_test_suite.py
+++ b/tests/test_test_suite.py
@@ -150,12 +150,10 @@ def test_load_rejects_unknown_extension(tmp_path):
 def test_cases_from_data_builds_cases():
     """A list of directive mappings becomes CLITestCase instances."""
     cases = list(
-        cases_from_data(
-            [
-                {"cli_parameters": "--version", "exit_code": 0},
-                {"cli_parameters": "--help"},
-            ]
-        )
+        cases_from_data([
+            {"cli_parameters": "--version", "exit_code": 0},
+            {"cli_parameters": "--help"},
+        ])
     )
     assert len(cases) == 2
     assert all(isinstance(c, CLITestCase) for c in cases)


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`a5cfdc14`](https://github.com/kdeldycke/click-extra/commit/a5cfdc14f2349d4073e00ca8a8e04242d90faad8) |
| **Job** | [`format-python`](https://github.com/kdeldycke/click-extra/blob/a5cfdc14f2349d4073e00ca8a8e04242d90faad8/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/a5cfdc14f2349d4073e00ca8a8e04242d90faad8/.github/workflows/autofix.yaml) |
| **Run** | [#2941.1](https://github.com/kdeldycke/click-extra/actions/runs/28079181315) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.29.0`