### PR TITLE
Format JSON

### DIFF
--- a/tests/carapace-spec.schema.json
+++ b/tests/carapace-spec.schema.json
@@ -1,181 +1,175 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/carapace-sh/carapace-spec/command",
-  "$ref": "#/$defs/Command",
-  "$defs": {
-    "Command": {
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Name of the command"
-        },
-        "aliases": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "Aliases of the command"
-        },
-        "description": {
-          "type": "string",
-          "description": "Description of the command"
-        },
-        "group": {
-          "type": "string",
-          "description": "Group of the command"
-        },
-        "hidden": {
-          "type": "boolean",
-          "description": "Hidden state of the command"
-        },
-        "parsing": {
-          "type": "string",
-          "enum": [
-            "interspersed",
-            "non-interspersed",
-            "disabled"
-          ],
-          "description": "Flag parsing mode of the command"
-        },
-        "flags": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "type": "object",
-          "description": "Flags of the command with their description"
-        },
-        "persistentflags": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "type": "object",
-          "description": "Persistent flags of the command with their description"
-        },
-        "exclusiveflags": {
-          "items": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "type": "array",
-          "description": "Flags that are mutually exclusive"
-        },
-        "run": {
-          "type": "string",
-          "description": "Command or script to execute in runnable mode"
-        },
-        "completion": {
-          "properties": {
-            "flag": {
-              "additionalProperties": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "type": "object",
-              "description": "Flag completion"
-            },
-            "positional": {
-              "items": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "type": "array",
-              "description": "Positional completion"
-            },
-            "positionalany": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array",
-              "description": "Positional completion for every other position"
-            },
-            "dash": {
-              "items": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "type": "array",
-              "description": "Dash completion"
-            },
-            "dashany": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array",
-              "description": "Dash completion of every other position"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "description": "Completion definition"
-        },
-        "commands": {
-          "items": {
-            "$ref": "#/$defs/Command"
-          },
-          "type": "array",
-          "description": "Subcommands of the command"
-        },
-        "documentation": {
-          "properties": {
-            "command": {
-              "type": "string",
-              "description": "Documentation of the command"
-            },
-            "flag": {
-              "additionalProperties": {
-                "type": "string"
-              },
-              "type": "object",
-              "description": "Documentation of flags"
-            },
-            "positional": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array",
-              "description": "Documentation of positional arguments"
-            },
-            "positionalany": {
-              "type": "string",
-              "description": "Documentation of other positional arguments"
-            },
-            "dash": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array",
-              "description": "Documentation of dash arguments"
-            },
-            "dashany": {
-              "type": "string",
-              "description": "Documentation of other dash arguments"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
-          "description": "Documentation"
-        },
-        "examples": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "type": "object",
-          "description": "Examples"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "name"
-      ]
-    }
-  }
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://github.com/carapace-sh/carapace-spec/command",
+	"$ref": "#/$defs/Command",
+	"$defs": {
+		"Command": {
+			"properties": {
+				"name": {
+					"type": "string",
+					"description": "Name of the command"
+				},
+				"aliases": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array",
+					"description": "Aliases of the command"
+				},
+				"description": {
+					"type": "string",
+					"description": "Description of the command"
+				},
+				"group": {
+					"type": "string",
+					"description": "Group of the command"
+				},
+				"hidden": {
+					"type": "boolean",
+					"description": "Hidden state of the command"
+				},
+				"parsing": {
+					"type": "string",
+					"enum": ["interspersed", "non-interspersed", "disabled"],
+					"description": "Flag parsing mode of the command"
+				},
+				"flags": {
+					"additionalProperties": {
+						"type": "string"
+					},
+					"type": "object",
+					"description": "Flags of the command with their description"
+				},
+				"persistentflags": {
+					"additionalProperties": {
+						"type": "string"
+					},
+					"type": "object",
+					"description": "Persistent flags of the command with their description"
+				},
+				"exclusiveflags": {
+					"items": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					},
+					"type": "array",
+					"description": "Flags that are mutually exclusive"
+				},
+				"run": {
+					"type": "string",
+					"description": "Command or script to execute in runnable mode"
+				},
+				"completion": {
+					"properties": {
+						"flag": {
+							"additionalProperties": {
+								"items": {
+									"type": "string"
+								},
+								"type": "array"
+							},
+							"type": "object",
+							"description": "Flag completion"
+						},
+						"positional": {
+							"items": {
+								"items": {
+									"type": "string"
+								},
+								"type": "array"
+							},
+							"type": "array",
+							"description": "Positional completion"
+						},
+						"positionalany": {
+							"items": {
+								"type": "string"
+							},
+							"type": "array",
+							"description": "Positional completion for every other position"
+						},
+						"dash": {
+							"items": {
+								"items": {
+									"type": "string"
+								},
+								"type": "array"
+							},
+							"type": "array",
+							"description": "Dash completion"
+						},
+						"dashany": {
+							"items": {
+								"type": "string"
+							},
+							"type": "array",
+							"description": "Dash completion of every other position"
+						}
+					},
+					"additionalProperties": false,
+					"type": "object",
+					"description": "Completion definition"
+				},
+				"commands": {
+					"items": {
+						"$ref": "#/$defs/Command"
+					},
+					"type": "array",
+					"description": "Subcommands of the command"
+				},
+				"documentation": {
+					"properties": {
+						"command": {
+							"type": "string",
+							"description": "Documentation of the command"
+						},
+						"flag": {
+							"additionalProperties": {
+								"type": "string"
+							},
+							"type": "object",
+							"description": "Documentation of flags"
+						},
+						"positional": {
+							"items": {
+								"type": "string"
+							},
+							"type": "array",
+							"description": "Documentation of positional arguments"
+						},
+						"positionalany": {
+							"type": "string",
+							"description": "Documentation of other positional arguments"
+						},
+						"dash": {
+							"items": {
+								"type": "string"
+							},
+							"type": "array",
+							"description": "Documentation of dash arguments"
+						},
+						"dashany": {
+							"type": "string",
+							"description": "Documentation of other dash arguments"
+						}
+					},
+					"additionalProperties": false,
+					"type": "object",
+					"description": "Documentation"
+				},
+				"examples": {
+					"additionalProperties": {
+						"type": "string"
+					},
+					"type": "object",
+					"description": "Examples"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object",
+			"required": ["name"]
+		}
+	}
 }


### PR DESCRIPTION
### Description

Auto-formats JSON files with [Biome](https://biomejs.dev/). See the [`format-json` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize JSON formatting via [`[tool.biome]`](https://biomejs.dev/reference/configuration/) in your `pyproject.toml`, or via a native `biome.json` file.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`877d99f1`](https://github.com/kdeldycke/click-extra/commit/877d99f17b53db3d521ea9614f0fe4d8a0360bb4) |
| **Job** | [`format-json`](https://github.com/kdeldycke/click-extra/blob/877d99f17b53db3d521ea9614f0fe4d8a0360bb4/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/877d99f17b53db3d521ea9614f0fe4d8a0360bb4/.github/workflows/autofix.yaml) |
| **Run** | [#2942.1](https://github.com/kdeldycke/click-extra/actions/runs/28082549959) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.29.0`