### PR TITLE
Format Python

### DIFF
--- a/click_extra/parameters.py
+++ b/click_extra/parameters.py
@@ -295,8 +295,7 @@ class _ParameterMixin:
                 # into an empty tuple.
                 if default_value is not None:
                     default_value = tuple(
-                        self.type.get_choice_string(member)
-                        for member in default_value
+                        self.type.get_choice_string(member) for member in default_value
                     )
             else:
                 default_value = self.type.get_choice_string(default_value)


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`8e4d5e82`](https://github.com/kdeldycke/click-extra/commit/8e4d5e820fab0fe5db66bb1e4bbf21a87c595046) |
| **Job** | [`format-python`](https://github.com/kdeldycke/click-extra/blob/8e4d5e820fab0fe5db66bb1e4bbf21a87c595046/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/8e4d5e820fab0fe5db66bb1e4bbf21a87c595046/.github/workflows/autofix.yaml) |
| **Run** | [#2950.1](https://github.com/kdeldycke/click-extra/actions/runs/28104285196) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.30.0`