### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -216,14 +216,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.4.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-06-24`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click](https://pypi.org/project/click/) | [`8.4.1` → `8.4.2`](https://github.com/pallets/click/compare/8.4.1...8.4.2) | 2026-06-24 (a week ago) |

### 🔜 Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window. Each becomes lockable on its eligible date.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [bracex](https://pypi.org/project/bracex/) | `2.6` | `3.0` | 2026-06-30 (a day ago) | 2026-07-07 (in 6 days) |
| [rpds-py](https://pypi.org/project/rpds-py/) | `2026.5.1` | `2026.6.3` | 2026-06-30 (a day ago) | 2026-07-07 (in 6 days) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | `3.11.0` | `3.12.0` | 2026-06-25 (6 days ago) | 2026-07-02 (in a day) |
| [wcmatch](https://pypi.org/project/wcmatch/) | `10.1` | `10.2` | 2026-06-30 (a day ago) | 2026-07-07 (in 6 days) |
| [wcwidth](https://pypi.org/project/wcwidth/) | `0.8.1` | `0.8.2` | 2026-06-29 (2 days ago) | 2026-07-06 (in 5 days) |

### Release notes

<details>
<summary><code>click</code></summary>

#### [`8.4.2`](https://github.com/pallets/click/releases/tag/8.4.2)

This is the Click 8.4.1 fix release, which fixes bugs but does not otherwise change behavior and should not result in breaking changes compared to the latest feature release.

PyPI: https://pypi.org/project/click/8.4.2/
Changes: https://click.palletsprojects.com/page/changes/#version-8-4-2
Milestone: https://redirect.github.com/pallets/click/milestone/34

- Fix Fish shell completion broken in `8.4.0` by #​3126. Newlines and
  tabs in option help text are now escaped, keeping the original completion
  format while still supporting multi-line help. #​3502
  #​3043 #​3504 #​3508
- Deprecated commands and options with empty or missing help text no longer
  render a stray leading space before the `(DEPRECATED)` label. #​3509
- A {class}`Group` with `invoke_without_command=True` marks its subcommand as
  optional in the usage help, showing `[COMMAND]` instead of `COMMAND`.
  #​3059 #​3507
- `echo_via_pager` flushes after each write, so passing a generator streams
  output to the pager incrementally instead of staying hidden until the pipe
  buffer fills. #​3242 #​2542 #​3534
- `echo_via_pager` and `get_pager_file` no longer close a borrowed stdout
  stream when no external pager runs, completing the partial
  `I/O operation on closed file` fix from #​3482. #​3449
  #​3533
- Fix CLI usage symopsis for optional arguments producing double square brackets
  `[[a|b|c]]...` whose type already brackets their metavar. #​3578
- {func}`version_option` resolves a `package_name` that does not match an
  installed distribution as an import (top-level module) name via
  {func}`importlib.metadata.packages_distributions`. Packages whose
  top-level module name differs from their distribution name (`PIL` vs
  `Pillow`, `jwt` vs `PyJWT`) no longer raise `RuntimeError` out of the
  box. #​2331 #​1884 #​3125 #​3582

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`08c63789`](https://github.com/kdeldycke/click-extra/commit/08c6378988f86493b2dd9e9dcd98085167874e65) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/click-extra/blob/08c6378988f86493b2dd9e9dcd98085167874e65/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/08c6378988f86493b2dd9e9dcd98085167874e65/.github/workflows/autofix.yaml) |
| **Run** | [#2997.1](https://github.com/kdeldycke/click-extra/actions/runs/28543614371) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.31.0`