### PR TITLE
Format Python

### DIFF
--- a/click_extra/sphinx/matrix.py
+++ b/click_extra/sphinx/matrix.py
@@ -381,7 +381,9 @@ def python_matrix_groups(
     return [PythonMatrixGroup(f, l, d, v) for f, l, d, v in merged]
 
 
-def _spans_full_major(first_tag: str, last_tag: str, next_first_tag: str | None) -> bool:
+def _spans_full_major(
+    first_tag: str, last_tag: str, next_first_tag: str | None
+) -> bool:
     """Whether a group covers an entire major series (so it labels as ``X.x``).
 
     True when the group stays within one major, starts at that major's ``.0``
@@ -658,9 +660,14 @@ def _dependency_columns(specs: list[str], latest: str) -> list[tuple[Version, bo
             continue
         patches = {Version(f"{major}.{minor}.0")}
         patches.update(
-            floor for floor, is_open in floors if is_open and (floor.major, floor.minor) == key
+            floor
+            for floor, is_open in floors
+            if is_open and (floor.major, floor.minor) == key
         )
-        if latest_version is not None and (latest_version.major, latest_version.minor) == key:
+        if (
+            latest_version is not None
+            and (latest_version.major, latest_version.minor) == key
+        ):
             patches.add(latest_version)
         columns.extend((patch, False) for patch in sorted(patches))
     return columns

--- a/tests/sphinx/test_sphinx_matrix.py
+++ b/tests/sphinx/test_sphinx_matrix.py
@@ -128,7 +128,7 @@ def synthetic_repo(tmp_path: Path) -> Path:
 
     # Tag v1.0.0: Poetry-style declaration, no classifiers.
     (repo / "pyproject.toml").write_text(
-        "[tool.poetry.dependencies]\npython = \"^3.10\"\n"
+        '[tool.poetry.dependencies]\npython = "^3.10"\n'
     )
     run("git", "add", "pyproject.toml")
     run("git", "commit", "-m", "v1.0.0", "--quiet")
@@ -137,10 +137,10 @@ def synthetic_repo(tmp_path: Path) -> Path:
     # Tag v2.0.0: PEP 621 + classifiers.
     (repo / "pyproject.toml").write_text(
         '[project]\nrequires-python = ">=3.11"\n'
-        'classifiers = [\n'
+        "classifiers = [\n"
         '  "Programming Language :: Python :: 3.11",\n'
         '  "Programming Language :: Python :: 3.12",\n'
-        ']\n'
+        "]\n"
     )
     run("git", "add", "pyproject.toml")
     run("git", "commit", "-m", "v2.0.0", "--quiet")
@@ -472,9 +472,7 @@ def synthetic_dep_repo(tmp_path: Path) -> Path:
     run("git", "config", "user.name", "T")
     run("git", "config", "commit.gpgsign", "false")
 
-    (repo / "pyproject.toml").write_text(
-        '[project]\ndependencies = ["widget>=1.0"]\n'
-    )
+    (repo / "pyproject.toml").write_text('[project]\ndependencies = ["widget>=1.0"]\n')
     run("git", "add", "pyproject.toml")
     run("git", "commit", "-m", "v1.0.0", "--quiet")
     run("git", "tag", "v1.0.0")
@@ -496,7 +494,9 @@ def test_dependency_matrix_groups(synthetic_dep_repo: Path) -> None:
 
 
 def test_dependency_matrix_table_columns_and_cells(synthetic_dep_repo: Path) -> None:
-    table = dependency_matrix_table(synthetic_dep_repo, "proj", "widget", show_spec=True)
+    table = dependency_matrix_table(
+        synthetic_dep_repo, "proj", "widget", show_spec=True
+    )
     # Minor 1.0 stays grouped; the open >=2.1.3 floor splits 2.1 into .0 / .3.
     assert "`1.0`" in table
     assert "`2.1.0`" in table


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`5ab466ac`](https://github.com/kdeldycke/click-extra/commit/5ab466ac64b780fd91a111bebd30645653dc53ef) |
| **Job** | [`format-python`](https://github.com/kdeldycke/click-extra/blob/5ab466ac64b780fd91a111bebd30645653dc53ef/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/5ab466ac64b780fd91a111bebd30645653dc53ef/.github/workflows/autofix.yaml) |
| **Run** | [#2999.1](https://github.com/kdeldycke/click-extra/actions/runs/28544043591) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.31.0`