### PR TITLE
Format Markdown

### DIFF
--- a/docs/sphinx.md
+++ b/docs/sphinx.md
@@ -857,7 +857,7 @@ The `matrix` directive renders a package's release compatibility matrix for a gi
 
 The generated table lives **in the source**, kept current by the offline updater described below, so it shows up in the raw Markdown (and in pull-request diffs) and the HTML build needs no git access (it works on a shallow clone). There are two ways to write it, both refreshed by the same `refresh-directives` command:
 
-- **A directive fence**, `` ```{matrix} python `` … `` ``` ``, rendered by Sphinx. Simplest on a docs-only page, but GitHub shows the fenced block as a code block. An empty fence falls back to generating from the git tags at build time, so a freshly authored block renders before its first refresh.
+- **A directive fence**, ```` ```{matrix} python ```` … ```` ``` ````, rendered by Sphinx. Simplest on a docs-only page, but GitHub shows the fenced block as a code block. An empty fence falls back to generating from the git tags at build time, so a freshly authored block renders before its first refresh.
 - **A comment marker region**, `<!-- matrix python -->` … `<!-- matrix-end -->`, with the raw table between the markers. Being plain Markdown, it renders as a real table on **GitHub** and PyPI as well as in Sphinx. Options go in the start comment as `key=value` pairs and bare flags: `<!-- matrix click show-spec -->`. `install.md`'s tables use this form so they render everywhere.
 
 The examples below use the directive fence; the marker form takes the same axis and options.


### PR DESCRIPTION
### Description

Auto-formats Markdown files with [mdformat](https://github.com/hukkin/mdformat) and its plugins. See the [`format-markdown` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize Markdown formatting via [`[tool.mdformat]`](https://mdformat.readthedocs.io/en/stable/users/configuration_file.html) in your `pyproject.toml`, or via a native `.mdformat.toml` file.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`4dedc3af`](https://github.com/kdeldycke/click-extra/commit/4dedc3af9496f328c45e82d2eb4ff6272f931f10) |
| **Job** | [`format-markdown`](https://github.com/kdeldycke/click-extra/blob/4dedc3af9496f328c45e82d2eb4ff6272f931f10/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/4dedc3af9496f328c45e82d2eb4ff6272f931f10/.github/workflows/autofix.yaml) |
| **Run** | [#3000.1](https://github.com/kdeldycke/click-extra/actions/runs/28546972668) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.31.0`