### PR TITLE
Format Python

### DIFF
--- a/docs/styling.md
+++ b/docs/styling.md
@@ -149,7 +149,11 @@ While `from_ansi()` parses bare escapes, `split_ansi()` tokenizes a whole string
 ```{python:run}
 from click_extra import Style, split_ansi, style
 
-runs = list(split_ansi(style("Monday", fg="blue") + " was " + style("sunny", fg="yellow", bold=True)))
+runs = list(
+    split_ansi(
+        style("Monday", fg="blue") + " was " + style("sunny", fg="yellow", bold=True)
+    )
+)
 assert runs == [
     (Style(fg="blue"), "Monday"),
     (Style(), " was "),
@@ -164,8 +168,10 @@ for run_style, text in runs:
 ```{python:run}
 from click_extra import render_ansi, style
 
+
 def brackets(run_style, text):
     return f"[{text}]"
+
 
 result = render_ansi("a " + style("styled", fg="red") + " word", brackets)
 assert result == "a [styled] word"
@@ -182,11 +188,19 @@ Four ready-made converters translate ANSI styling to markup languages with nativ
 - `ansi_to_textile()` produces `%{…}` spans carrying the style as inline CSS.
 
 ```{python:run}
-from click_extra import ansi_to_html, ansi_to_jira, ansi_to_latex, ansi_to_textile, style
+from click_extra import (
+    ansi_to_html,
+    ansi_to_jira,
+    ansi_to_latex,
+    ansi_to_textile,
+    style,
+)
 
 sample = style("Summer", fg="blue", bold=True)
 
-assert ansi_to_html(sample) == '<span style="color: blue; font-weight: bold">Summer</span>'
+assert (
+    ansi_to_html(sample) == '<span style="color: blue; font-weight: bold">Summer</span>'
+)
 assert ansi_to_jira(sample) == "{color:blue}*Summer*{color}"
 assert ansi_to_latex(sample) == "\\textcolor{blue}{\\textbf{Summer}}"
 assert ansi_to_textile(sample) == "%{color: blue; font-weight: bold}Summer%"


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`acadad01`](https://github.com/kdeldycke/click-extra/commit/acadad01186ee029b7b164316d25dd6a38ce4f9b) |
| **Job** | [`format-python`](https://github.com/kdeldycke/click-extra/blob/acadad01186ee029b7b164316d25dd6a38ce4f9b/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/acadad01186ee029b7b164316d25dd6a38ce4f9b/.github/workflows/autofix.yaml) |
| **Run** | [#3026.1](https://github.com/kdeldycke/click-extra/actions/runs/29449428934) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.1.0`