### PR TITLE
Sync action pins

### DIFF
--- a/.github/actions/publish-pypi/action.yaml
+++ b/.github/actions/publish-pypi/action.yaml
@@ -27,7 +27,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+    - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       with:
         enable-cache: false
         # Downstream callers invoke this action without a checkout (the codegen drops it: see

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,7 +59,7 @@ jobs:
       metadata: ${{ steps.metadata.outputs.metadata }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - name: Run repomatic metadata
         id: metadata
         run: >
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - name: Install Python
         run: uv --no-progress venv --python 3.14
 
@@ -162,7 +162,7 @@ jobs:
     continue-on-error: ${{ matrix.state == 'unstable' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - name: Force native ARM64 Python on Windows ARM64
         # Workaround for https://github.com/astral-sh/uv/issues/12906: uv defaults to x86_64 Python on ARM64 Windows,
         # relying on transparent emulation. Native extensions with Rust (e.g., test-results-parser from codecov-cli)


### PR DESCRIPTION
### Description

Bumps SHA-pinned GitHub Actions (`uses: owner/repo@<sha> # vX.Y.Z`) to their latest releases that have cleared the stabilization cooldown, resolving each release tag to its commit SHA. See the [`sync-action-pins` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### 🆙 Updated actions

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `7 days`: releases after `2026-07-08` are held back.

| Action | Change | Released |
| :-- | :-- | :-- |
| [astral-sh/setup-uv](https://github.com/astral-sh/setup-uv) | [`v8.2.0` → `v8.3.2`](https://github.com/astral-sh/setup-uv/compare/v8.2.0...v8.3.2) | 2026-07-08 (a week ago) |

### Release notes

<details>
<summary><code>astral-sh/setup-uv</code></summary>

#### [`v8.3.1`](https://github.com/astral-sh/setup-uv/releases/tag/v8.3.1)

## Changes

Just a maintenance release

## 🧰 Maintenance

- Change update-docs PR labels from 'update-docs' to 'documentation' @​eifinger (#​945)
- chore: update known checksums for 0.11.27 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​944)

## 📚 Documentation

- docs: update version references to v8.3.0 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​939)

#### [`v8.3.2`](https://github.com/astral-sh/setup-uv/releases/tag/v8.3.2)

## Changes

Just a maintenance release

## 🧰 Maintenance

- chore: update known checksums for 0.11.28 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​947)

## 📚 Documentation

- docs: update version references to v8.3.1 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​946)

## ⬆️ Dependency updates

- chore: roll up Dependabot updates @​eifinger (#​948)

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`action-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#action-pins-sync)
- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`acadad01`](https://github.com/kdeldycke/click-extra/commit/acadad01186ee029b7b164316d25dd6a38ce4f9b) |
| **Job** | [`sync-deps`](https://github.com/kdeldycke/click-extra/blob/acadad01186ee029b7b164316d25dd6a38ce4f9b/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/acadad01186ee029b7b164316d25dd6a38ce4f9b/.github/workflows/autofix.yaml) |
| **Run** | [#3026.1](https://github.com/kdeldycke/click-extra/actions/runs/29449428934) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.1.0`