### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -253,7 +253,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         shell: bash
         run: >
-          uvx --no-progress 'codecov-cli==11.2.8'
+          uvx --no-progress 'codecov-cli==11.3.0'
           --auto-load-params-from githubactions
           upload-process
           --git-service github


### PR DESCRIPTION
### Description

Bumps npm and PyPI version literals embedded in workflow YAML (`npm install pkg@x`, `uvx '<pkg>==x'`) to their latest releases that have cleared the stabilization cooldown. See the [`sync-workflow-pins` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `7 days`: releases after `2026-07-08` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [codecov-cli](https://pypi.org/project/codecov-cli/) | `11.2.8` → `11.3.0` | 2026-07-08 (a week ago) |

### 🔜 Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window. Each becomes adoptable on its eligible date.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [codecov-cli](https://pypi.org/project/codecov-cli/) | `11.3.0` | `11.3.1` | 2026-07-09 (6 days ago) | 2026-07-16 (in a day) |

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`acadad01`](https://github.com/kdeldycke/click-extra/commit/acadad01186ee029b7b164316d25dd6a38ce4f9b) |
| **Job** | [`sync-deps`](https://github.com/kdeldycke/click-extra/blob/acadad01186ee029b7b164316d25dd6a38ce4f9b/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/acadad01186ee029b7b164316d25dd6a38ce4f9b/.github/workflows/autofix.yaml) |
| **Run** | [#3026.1](https://github.com/kdeldycke/click-extra/actions/runs/29449428934) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.1.0`