### PR TITLE
Format Python

### DIFF
--- a/click_extra/config/option.py
+++ b/click_extra/config/option.py
@@ -589,9 +589,7 @@ class ConfigOption(ExtraOption, ParamStructure):
         help_option = cli.get_help_option(ctx)
         if help_option is not None and help_option.name is not None:
             excluded_ids.append(help_option.name)
-        return frozenset(
-            f"{cli.name}{PARAM_PATH_SEP}{p}" for p in excluded_ids
-        )
+        return frozenset(f"{cli.name}{PARAM_PATH_SEP}{p}" for p in excluded_ids)
 
     @cached_property
     def file_pattern(self) -> str:


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`d1706f11`](https://github.com/kdeldycke/click-extra/commit/d1706f110e86f9af8cd850f297da95e4ad44d43f) |
| **Job** | [`format-python`](https://github.com/kdeldycke/click-extra/blob/d1706f110e86f9af8cd850f297da95e4ad44d43f/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/d1706f110e86f9af8cd850f297da95e4ad44d43f/.github/workflows/autofix.yaml) |
| **Run** | [#3039.1](https://github.com/kdeldycke/click-extra/actions/runs/29471942808) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.1.0`