### PR TITLE
Bump minor version to `v8.5.0`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [`8.4.1.dev0` (unreleased)](https://github.com/kdeldycke/click-extra/compare/v8.4.0...main)
+## [`8.5.0.dev0` (unreleased)](https://github.com/kdeldycke/click-extra/compare/v8.4.0...main)
 
 > [!WARNING]
 > This version is **not released yet** and is under active development.

--- a/citation.cff
+++ b/citation.cff
@@ -8,8 +8,8 @@ authors:
     email: kevin@deldycke.com
     orcid: "https://orcid.org/0000-0001-9748-9014"
 doi: 10.5281/zenodo.7116050
-version: 8.4.1.dev0
+version: 8.5.0.dev0
 # The release date is kept up to date by the external workflows. See:
 # https://github.com/kdeldycke/workflows/blob/33b704b489c1aa18b7b7efbf963e153e91e1c810/.github/workflows/changelog.yaml#L135-L137
-date-released: 2026-07-16
+date-released: 2026-07-18
 url: "https://github.com/kdeldycke/click-extra"

--- a/click_extra/__init__.py
+++ b/click_extra/__init__.py
@@ -42,14 +42,14 @@ from click._utils import UNSET
 from click.core import ParameterSource
 
 # NoSuchCommand (PR pallets/click#3228) and get_pager_file (PR pallets/click#1572)
-# are Click 8.4.1.dev0 additions, absent on the Click 8.3.x releases click-extra still
+# are Click 8.5.0.dev0 additions, absent on the Click 8.3.x releases click-extra still
 # supports. Import them only when present so click-extra mirrors Click's own public
 # surface; the matching __all__ entries are trimmed below when they are missing.
 try:
     from click import NoSuchCommand, get_pager_file
 
     _HAS_CLICK_8_4_EXPORTS = True
-except ImportError:  # Click < 8.4.1.dev0.
+except ImportError:  # Click < 8.5.0.dev0.
     _HAS_CLICK_8_4_EXPORTS = False
 
 # Overrides click helpers with cloup's.
@@ -472,7 +472,7 @@ __all__ = [
     ``ruff`` via `RUF022 <https://docs.astral.sh/ruff/rules/unsorted-dunder-all/>`_.
 """
 
-# NoSuchCommand and get_pager_file are only re-exported on Click >= 8.4.1.dev0 (see the
+# NoSuchCommand and get_pager_file are only re-exported on Click >= 8.5.0.dev0 (see the
 # guarded import above). Drop them from the public API on older Click so ``__all__``
 # matches the names actually bound in this module.
 if not _HAS_CLICK_8_4_EXPORTS:
@@ -489,7 +489,7 @@ del annotations
 del warnings  # noqa: F821
 
 
-__version__ = "8.4.1.dev0"
+__version__ = "8.5.0.dev0"
 __git_branch__ = ""
 __git_date__ = ""
 __git_long_hash__ = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "uv-build>=0.9" ]
 [project]
 # Docs: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
 name = "click-extra"
-version = "8.4.1.dev0"
+version = "8.5.0.dev0"
 description = "🌈 Drop-in replacement for Click to make user-friendly and colorful CLI"
 readme = "readme.md"
 keywords = [
@@ -203,7 +203,7 @@ click-extra = "click_extra.__main__:main"
 
 [project.urls]
 "Homepage" = "https://github.com/kdeldycke/click-extra"
-"Download" = "https://github.com/kdeldycke/click-extra/releases/tag/v8.4.1.dev0"
+"Download" = "https://github.com/kdeldycke/click-extra/releases/tag/v8.5.0.dev0"
 "Changelog" = "https://github.com/kdeldycke/click-extra/blob/main/changelog.md"
 "Issues" = "https://github.com/kdeldycke/click-extra/issues"
 "Repository" = "https://github.com/kdeldycke/click-extra"
@@ -436,7 +436,7 @@ report.precision = 2
 file = "tests/cli-test-suite.toml"
 
 [tool.bumpversion]
-current_version = "8.4.1.dev0"
+current_version = "8.5.0.dev0"
 # Parse versions with an optional .devN suffix (PEP 440).
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(\\.dev(?P<dev>\\d+))?"
 serialize = [

--- a/uv.lock
+++ b/uv.lock
@@ -210,7 +210,7 @@ wheels = [
 
 [[package]]
 name = "click-extra"
-version = "8.4.1.dev0"
+version = "8.5.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "boltons" },


### PR DESCRIPTION
### Description

Ready to be merged into `main` branch, at the discretion of the maintainers, to bump the minor part of the version number. Version bumps are scheduled daily and also triggered after releases. See the [`bump-version` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-changelog-yaml-jobs) for details.

### To bump version to `v8.5.0`

1. **Click `Ready for review`** button below, to get this PR out of `Draft` mode

2. **Click `Rebase and merge`** button below


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `schedule` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`ea39c483`](https://github.com/kdeldycke/click-extra/commit/ea39c483f980461b81394edda54aa714013a73a3) |
| **Job** | [`bump-version`](https://github.com/kdeldycke/click-extra/blob/ea39c483f980461b81394edda54aa714013a73a3/.github/workflows/changelog.yaml) |
| **Workflow** | [`changelog.yaml`](https://github.com/kdeldycke/click-extra/blob/ea39c483f980461b81394edda54aa714013a73a3/.github/workflows/changelog.yaml) |
| **Run** | [#1577.1](https://github.com/kdeldycke/click-extra/actions/runs/29635708995) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.1.0`