### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Run repomatic metadata
         id: metadata
         run: >
-          uvx --no-progress 'repomatic==7.1.0' metadata
+          uvx --no-progress 'repomatic==7.3.0' metadata
           --format github-json --output "$GITHUB_OUTPUT"
           coverage_cells test_matrix test_matrix_pr
 


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `7 days`: releases after `2026-07-16` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [repomatic](https://pypi.org/project/repomatic/) | `7.1.0` → `7.3.0` | [⛓️ lockstep with `uses:` refs](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater) |

### Release notes

<details>
<summary><code>repomatic</code></summary>

#### [`v7.2.0`](https://github.com/kdeldycke/repomatic/releases/tag/v7.2.0)

> [!NOTE]
> `7.2.0` is available on [🐍 PyPI](https://pypi.org/project/repomatic/7.2.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/repomatic/releases/tag/v7.2.0).

- **Breaking:** the `release-prep` command is renamed `prepare-release`, matching the job, template, and PR branch it drives; its module moves to `repomatic.prepare_release` and its class becomes `PrepareRelease`.
- **Breaking:** the `version-check` command is renamed `check-version`.
- **Breaking:** the vulnerability audit domain moves from `repomatic.uv` into the new `repomatic.vulnerable_deps` module, which also absorbs `repomatic.github.advisories`.
- **Breaking:** `repomatic.sponsor` moves under `repomatic.github`.
- **Breaking:** the PR-body helpers (`generate_pr_metadata_block`, `generate_refresh_tip`, `build_pr_body`) now take their CI context as arguments; `current_repo_url` is removed.
- **Breaking:** `build_expected_body` moves from `repomatic.github.release_sync` to `repomatic.changelog`.
- **Breaking:** the five `check_pat_*` probe functions are replaced by the `PAT_PERMISSION_PROBES` table and `probe_pat_permission`.
- **Breaking:** the workflow generation API (`generate_thin_caller`, `generate_workflow_header`, `generate_workflows`) drops its legacy `source_paths` argument; pass a `PathsSpec` instead.
- Add `cancel-runs`: cancels a branch's in-progress and queued workflow runs, replacing the bash block in `cancel-runs.yaml`; run listings now paginate past the first page.
- Add `[tool.repomatic] binaries.sync`: set to `false` to stop the release pipeline from committing the binaries catalog and scan records to the default branch.
- Add `sync-dep-sources`, a fifth `sync-deps` updater: once the release named by a git-tracked dependency's `.dev` floor ships on PyPI, it drops the `[tool.uv.sources]` override, tightens the floor, and freezes the adopted release through the cooldown. Disable with `[tool.repomatic] dep-sources.sync`.

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v7.2.0)

#### [`v7.3.0`](https://github.com/kdeldycke/repomatic/releases/tag/v7.3.0)

> [!NOTE]
> `7.3.0` is available on [🐍 PyPI](https://pypi.org/project/repomatic/7.3.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/repomatic/releases/tag/v7.3.0).

- **Breaking:** Move the MyST docstring toolchain upstream to click-extra, now floored at `8.5`: the `repomatic.myst_docstrings` Sphinx extension becomes `click_extra.sphinx.myst_docstrings` (point `conf.py` at the new module path), and the `convert-to-myst` command becomes `click-extra convert-to-myst`.
- Warn on unknown `[tool.repomatic]` keys through click-extra's schema layer, covering nested tables too; the warning now names keys in snake_case.
- Upload each release binary under a versionless alias, so the stable `releases/latest/download` URLs keep resolving across releases.
- Mark the upstream toolkit's lockstep-aligned pin with a `⛓️ lockstep` docs link in the `sync-workflow-pins` PR table, instead of an empty `Released` cell.
- Add a ⚙️ emoji to the `Configuration` section heading of PR bodies, and swap the `Held back by cooldown` section's 🔜 emoji for ⏸️.
- Disable ruff's `unsafe-fixes` in the bundled defaults, so `--fix` and the autofix workflow only apply semantics-preserving fixes.
- Expose `GITHUB_TOKEN` to the Sphinx linkcheck step of the docs workflow, so a repo's `conf.py` can authenticate its github.com checks via `linkcheck_request_headers`.
- Space out the Windows exiftool install with step-level retries, absorbing Chocolatey community-feed outages that punch through choco's own `--retry-count`.
- Fix the `exclude` and `include` configuration reference to list `agents` among the default-excluded components.
- Skip directories and hidden files when validating packaged PR templates, so local tool droppings no longer fail the suite.
- Exclude `once`-marked tests from every test-matrix cell and run them in a dedicated single-runner `once-tests` job with its own coverage upload.
- Run the CLI self-test suite through `python -m` in addition to the console script.

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v7.3.0)

</details>

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`878726a1`](https://github.com/kdeldycke/click-extra/commit/878726a1ba8bb88127d6d945076c1b41fb034ee2)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/click-extra/blob/878726a1ba8bb88127d6d945076c1b41fb034ee2/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/878726a1ba8bb88127d6d945076c1b41fb034ee2/.github/workflows/autofix.yaml)
- **Run**: [#3063.1](https://github.com/kdeldycke/click-extra/actions/runs/30010773539)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.3.0`