### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -590,11 +590,11 @@ wheels = [
 
 [[package]]
 name = "extra-platforms"
-version = "13.2.0"
+version = "13.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/84/cd/823e004612fa7ae3110a5a3e1383618c5a4198b0cdae47be74331122a397/extra_platforms-13.2.0.tar.gz", hash = "sha256:0f88c3ae147e175b9ce230874377a6f769b8e6bde8a5d8beee2ae77c60521a15", size = 83506, upload-time = "2026-07-15T21:20:13.155Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/ca/61eceac99e45bfc626f83adb9b1682dc18ac00dff5a55163d54190f6ec2a/extra_platforms-13.3.0.tar.gz", hash = "sha256:e9cff5256f7e26d4d6cf7118f22994f51e75474ee5ec15ce6a2085c84b4c2d9b", size = 86107, upload-time = "2026-07-17T09:51:30.111Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/9f/15543dea0bad0dab4aa9bdbe2ece05a383cdd12138fa03eac83e7c1e9c76/extra_platforms-13.2.0-py3-none-any.whl", hash = "sha256:178ad1cf567de078de58ce72c2f7049713980f14812d57b4a9c3250836446798", size = 86088, upload-time = "2026-07-15T21:20:11.62Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/eb/fea772c223a6c7f5d05155293610313bfc285f9d1612eb8d768fe787203c/extra_platforms-13.3.0-py3-none-any.whl", hash = "sha256:ebdd1c800c0bbc83e2bfe55bba81742f27942ba0c07f3f46e1903fdd677228a0", size = 89798, upload-time = "2026-07-17T09:51:28.725Z" },
 ]
 
 [package.optional-dependencies]
@@ -1852,11 +1852,11 @@ wheels = [
 
 [[package]]
 name = "tomlkit"
-version = "0.15.0"
+version = "0.15.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz", hash = "sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3", size = 161875, upload-time = "2026-05-10T07:38:22.245Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/96/e07752635b98536177fa1f37671c8f3cdde2e724c6bcf6034b2cfb571565/tomlkit-0.15.1.tar.gz", hash = "sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97", size = 180129, upload-time = "2026-07-17T01:48:04.562Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl", hash = "sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738", size = 41328, upload-time = "2026-05-10T07:38:23.517Z" },
+    { url = "https://files.pythonhosted.org/packages/13/bc/8c13eb66537dce1d2bd3a57132902f38d0e7f5bb46fa9f4daed9fe9d76ee/tomlkit-0.15.1-py3-none-any.whl", hash = "sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304", size = 49449, upload-time = "2026-07-17T01:48:05.728Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-07-17`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | [`13.2.0` → `13.3.0`](https://github.com/kdeldycke/extra-platforms/compare/v13.2.0...v13.3.0) | 2026-07-17 (a week ago) |
| [tomlkit](https://pypi.org/project/tomlkit/) | [`0.15.0` → `0.15.1`](https://github.com/python-poetry/tomlkit/compare/0.15.0...0.15.1) | 2026-07-17 (a week ago) |

### Release notes

<details>
<summary><code>extra-platforms</code></summary>

#### [`v13.3.0`](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.3.0)

> [!NOTE]
> `13.3.0` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/13.3.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v13.3.0).

- Deprecate the `TUMBLEWEED` platform: openSUSE Tumbleweed is now detected as `OPENSUSE`. `TUMBLEWEED`, `is_tumbleweed()` and the `skip_tumbleweed`/`unless_tumbleweed` decorators still resolve to their `OPENSUSE` counterparts with a `DeprecationWarning`, and will be removed in `14.0.0`.
- Detect all openSUSE release channels (Tumbleweed, Leap, Slowroll, MicroOS, ...) as `OPENSUSE`. Closes [#​619](https://redirect.github.com/kdeldycke/extra-platforms/issues/619)
- `Platform.info()` now reports the raw `os-release` ID of distribution sub-variants in its `distro_id` field (like `ol` or `opensuse-slowroll`) instead of aliasing it to the canonical platform ID.
- Rename `NON_OVERLAPPING_GROUPS` to `CANONICAL_GROUPS` and `EXTRA_GROUPS` to `NON_CANONICAL_GROUPS`, matching the `Group.canonical` vocabulary. The old names still resolve with a `DeprecationWarning`, and will be removed in `14.0.0`.
- `Trait.info()` is now implemented by the base class with identity metadata: custom `Trait` subclasses are no longer forced to override it.
- Rename the `ALL_CI` group to "All CI systems" and `ALL_AGENTS` to "All AI coding agents", aligning with the other "all" group names.
- `current_traits()` now returns an immutable `frozenset`: mutating the previously returned `set` corrupted its cache.
- `linux_info()` now returns `None` for missing fields instead of empty strings, like `macos_info()` and `windows_info()`.
- Fix pytest decorator skip reasons mangling acronyms and brand names ("Skip cI systems" is now "Skip All CI systems").
- Fix grammar and labels of the `current_*()` multiple-match errors ("Multiple CI matches:" is now "Multiple CI systems match:").
- Fix the `cff-version` schema field in `citation.cff` being overwritten with the package version on every version bump.

... [Full release notes](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.3.0)

</details>

<details>
<summary><code>tomlkit</code></summary>

#### [`0.15.1`](https://github.com/python-poetry/tomlkit/releases/tag/0.15.1)

##### What's Changed
* Fix inline table separator after append by @​cyliu0 in https://redirect.github.com/python-poetry/tomlkit/pull/477
* chore(deps): bump idna from 3.7 to 3.15 in /docs by @​dependabot[bot] in https://redirect.github.com/python-poetry/tomlkit/pull/481
* chore(deps-dev): bump idna from 3.7 to 3.15 by @​dependabot[bot] in https://redirect.github.com/python-poetry/tomlkit/pull/480
* chore(deps): bump urllib3 from 2.5.0 to 2.7.0 in /docs by @​dependabot[bot] in https://redirect.github.com/python-poetry/tomlkit/pull/475
* [pre-commit.ci] pre-commit autoupdate by @​pre-commit-ci[bot] in https://redirect.github.com/python-poetry/tomlkit/pull/478
* [pre-commit.ci] pre-commit autoupdate by @​pre-commit-ci[bot] in https://redirect.github.com/python-poetry/tomlkit/pull/484
* Fix duplicated comma when removing a middle inline table element by @​sarathfrancis90 in https://redirect.github.com/python-poetry/tomlkit/pull/486
* Add native __contains__ to Container, Table and InlineTable by @​tfoutrein in https://redirect.github.com/python-poetry/tomlkit/pull/487
* Make Source index-based instead of materializing a char list by @​tfoutrein in https://redirect.github.com/python-poetry/tomlkit/pull/489
* reject surrogate code points in \U unicode escapes by @​netliomax25-code in https://redirect.github.com/python-poetry/tomlkit/pull/493
* [pre-commit.ci] pre-commit autoupdate by @​pre-commit-ci[bot] in https://redirect.github.com/python-poetry/tomlkit/pull/496
* Scan character runs in bulk while parsing by @​tfoutrein in https://redirect.github.com/python-poetry/tomlkit/pull/490
* Fix doubled comma when inserting into a comma-first array by @​gaoflow in https://redirect.github.com/python-poetry/tomlkit/pull/499
* reject tab characters in bare keys by @​netliomax25-code in https://redirect.github.com/python-poetry/tomlkit/pull/497
* reject non-hex digits in \u and \U escapes by @​netliomax25-code in https://redirect.github.com/python-poetry/tomlkit/pull/501

... [Full release notes](https://github.com/python-poetry/tomlkit/releases/tag/0.15.1)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [boltons](https://pypi.org/project/boltons/) | `26.0.0` | `26.1.0` | 2026-07-17 (a week ago) | 2026-07-24 (just now) |
| [bracex](https://pypi.org/project/bracex/) | `3.0` | `3.0.1` | 2026-07-20 (4 days ago) | 2026-07-27 (in 3 days) |
| [certifi](https://pypi.org/project/certifi/) | `2026.6.17` | `2026.7.22` | 2026-07-22 (2 days ago) | 2026-07-29 (in 5 days) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.3.0` | `13.3.1` | 2026-07-17 (a week ago) | 2026-07-24 (just now) |
| [platformdirs](https://pypi.org/project/platformdirs/) | `4.10.0` | `4.11.0` | 2026-07-21 (3 days ago) | 2026-07-28 (in 4 days) |
| [soupsieve](https://pypi.org/project/soupsieve/) | `2.8.4` | `2.9.1` | 2026-07-21 (3 days ago) | 2026-07-28 (in 4 days) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | `3.12.1` | `3.13.0` | 2026-07-21 (3 days ago) | 2026-07-28 (in 4 days) |
| [sphinxcontrib-mermaid](https://pypi.org/project/sphinxcontrib-mermaid/) | `2.0.3` | `2.1.0` | 2026-07-18 (6 days ago) | 2026-07-25 (in a day) |
| [types-boltons](https://pypi.org/project/types-boltons/) | `25.0.0.20260612` | `26.1.0.20260724` | 2026-07-24 (just now) | 2026-07-31 (in a week) |
| [types-docutils](https://pypi.org/project/types-docutils/) | `0.22.3.20260712` | `0.22.3.20260724` | 2026-07-24 (just now) | 2026-07-31 (in a week) |
| [types-pyyaml](https://pypi.org/project/types-pyyaml/) | `6.0.12.20260518` | `6.0.12.20260724` | 2026-07-24 (just now) | 2026-07-31 (in a week) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://kdeldycke.github.io/repomatic/workflows.html#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`ac033e36`](https://github.com/kdeldycke/click-extra/commit/ac033e362a98a2bddf5c3b150bd6511d7546d542)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/click-extra/blob/ac033e362a98a2bddf5c3b150bd6511d7546d542/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/ac033e362a98a2bddf5c3b150bd6511d7546d542/.github/workflows/autofix.yaml)
- **Run**: [#3074.1](https://github.com/kdeldycke/click-extra/actions/runs/30084708721)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.3.0`