### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -84,11 +84,11 @@ wheels = [
 
 [[package]]
 name = "boltons"
-version = "26.0.0"
+version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7a/1f/60df922ae497d838c58b48caa518251e2c8e228d7fe93792fee69a3858d6/boltons-26.0.0.tar.gz", hash = "sha256:5566d6cfd5a1e873d8e8476496287a9f92979964611ad9a9cecb6b0ef29b1edd", size = 225129, upload-time = "2026-06-19T06:10:41.226Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/99/12bace94ae2ba961bdc46d49277ff15d38dba074bc3987b0c0b4355a37a7/boltons-26.1.0.tar.gz", hash = "sha256:5764468aba493b15995ed17f46a16789023f123ca2a62d491a9ce825c1cbe26c", size = 227393, upload-time = "2026-07-17T18:38:42.454Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/01/4001033457f25ecdc2b1ffd513ca0b76200b9ea009dd64f6c1aad2dde133/boltons-26.0.0-py3-none-any.whl", hash = "sha256:ba077cac51b27532299634f87f5589b4080fa94a011b4d43a9247f775e9215c7", size = 195559, upload-time = "2026-06-19T06:10:39.865Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/ba/cea118a16647cc72633c5236f6f11a09ab76b136b1aaccfa0d7004958428/boltons-26.1.0-py3-none-any.whl", hash = "sha256:1d966b165805b83600b31af9f0db672e3b3313d9de438e22708a94ac5f4c93de", size = 196095, upload-time = "2026-07-17T18:38:41.164Z" },
 ]
 
 [[package]]
@@ -590,11 +590,11 @@ wheels = [
 
 [[package]]
 name = "extra-platforms"
-version = "13.3.0"
+version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1a/ca/61eceac99e45bfc626f83adb9b1682dc18ac00dff5a55163d54190f6ec2a/extra_platforms-13.3.0.tar.gz", hash = "sha256:e9cff5256f7e26d4d6cf7118f22994f51e75474ee5ec15ce6a2085c84b4c2d9b", size = 86107, upload-time = "2026-07-17T09:51:30.111Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/c5/fae67f4681a664ad855b0cc219b89459f2144e144966b56abc2c63af2921/extra_platforms-13.3.1.tar.gz", hash = "sha256:1efefa780f0b97dce5d352f7873065988f7f23938af70456182b20474849d1c2", size = 86205, upload-time = "2026-07-17T14:02:38.235Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/eb/fea772c223a6c7f5d05155293610313bfc285f9d1612eb8d768fe787203c/extra_platforms-13.3.0-py3-none-any.whl", hash = "sha256:ebdd1c800c0bbc83e2bfe55bba81742f27942ba0c07f3f46e1903fdd677228a0", size = 89798, upload-time = "2026-07-17T09:51:28.725Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/77/aa1591668c391444dd4c30e29936cfaf42177ac9cc6073a681ca510bab02/extra_platforms-13.3.1-py3-none-any.whl", hash = "sha256:ffec89f6f5a983ea2be29970ee7144b2fa53a0fab381ce2b1ed447f4ad63d7a0", size = 89802, upload-time = "2026-07-17T14:02:36.684Z" },
 ]
 
 [package.optional-dependencies]
@@ -1021,11 +1021,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.10.0"
+version = "4.10.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/cd/4f25b2f95b23f5d2c9c1fe43e49841bff5800562149b2666afc09309aa8f/platformdirs-4.10.1.tar.gz", hash = "sha256:ceab4084426fe6319ce18e86deada8ab1b7487c7aee7040c55e277c9ae793695", size = 31678, upload-time = "2026-07-18T03:53:43.808Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/73/6fd0bb9ce84138c3857f12e9de63bc901852975a092d545f18087a204aa2/platformdirs-4.10.1-py3-none-any.whl", hash = "sha256:0e4eff26be2d75293977f7cddc153fd9b8eaa7fb0c7b64ffe4076cb443117443", size = 22906, upload-time = "2026-07-18T03:53:42.576Z" },
 ]
 
 [[package]]
@@ -1527,11 +1527,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.4"
+version = "2.9"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/f1/93422647dd7e461f23d254e6b2bfa687a85b53aeb4903fcdbb74474d4584/soupsieve-2.9.tar.gz", hash = "sha256:acee8417325c5653e1377dc31eccad59eb82cbc65942afe6174c53b3aaad63fc", size = 122122, upload-time = "2026-07-19T01:35:18.425Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d6/3185ab5ad1280319b31986898f3206dd7227cd75e293d4dba2a5e6bf27a0/soupsieve-2.9-py3-none-any.whl", hash = "sha256:a2b2c76d67df2382d245409fd71e321a571717e58463efa32ace87dcadac2c12", size = 37387, upload-time = "2026-07-19T01:35:17.106Z" },
 ]
 
 [[package]]
@@ -1740,16 +1740,16 @@ wheels = [
 
 [[package]]
 name = "sphinxcontrib-mermaid"
-version = "2.0.3"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
     { name = "pyyaml" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" } },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/29/54cf1f7e03630ca4859caba25bc192698954d7c630377c62d1e264715c37/sphinxcontrib_mermaid-2.0.3.tar.gz", hash = "sha256:a6865ef6b65b225c5403a3170de63a04a07227cada11a4a71a6b87b4f9ed185a", size = 20764, upload-time = "2026-07-08T00:30:44.216Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/9d/bf3a48a657682c7e0445c71d916bca7ab8194454276cc22b16e7f974e502/sphinxcontrib_mermaid-2.1.0.tar.gz", hash = "sha256:13c5f9ac395cb6abf403eca34e228dc9fb3a30c9d960dbf3e40e9a8cef969549", size = 21695, upload-time = "2026-07-18T23:08:11.265Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/57/b39c7a69b70a3ce999732bdb57fcaac78fb3cc8e2843a3daf1c1f821bc9d/sphinxcontrib_mermaid-2.0.3-py3-none-any.whl", hash = "sha256:f001ed36a55c108f6221a2d656a441c487ee30651b54db72b7c752a20c7a66e8", size = 15401, upload-time = "2026-07-08T00:30:42.877Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/bd/d3348d62296e73a91420f0edf671450c9003ecd8704da40b1e3d9b868459/sphinxcontrib_mermaid-2.1.0-py3-none-any.whl", hash = "sha256:417cd144ec4b28852f46ba653f02ce8e538881c812111671a4c30344e87f2112", size = 16190, upload-time = "2026-07-18T23:08:10.098Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-07-19`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [boltons](https://pypi.org/project/boltons/) | [`26.0.0` → `26.1.0`](https://github.com/mahmoud/boltons/compare/26.0.0...26.1.0) | 2026-07-17 (a week ago) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | [`13.3.0` → `13.3.1`](https://github.com/kdeldycke/extra-platforms/compare/v13.3.0...v13.3.1) | 2026-07-17 (a week ago) |
| [platformdirs](https://pypi.org/project/platformdirs/) | [`4.10.0` → `4.10.1`](https://github.com/tox-dev/platformdirs/compare/4.10.0...4.10.1) | 2026-07-18 (a week ago) |
| [soupsieve](https://pypi.org/project/soupsieve/) | [`2.8.4` → `2.9`](https://github.com/facelessuser/soupsieve/compare/2.8.4...2.9) | 2026-07-19 (a week ago) |
| [sphinxcontrib-mermaid](https://pypi.org/project/sphinxcontrib-mermaid/) | [`2.0.3` → `2.1.0`](https://github.com/mgaitan/sphinxcontrib-mermaid/compare/v2.0.3...v2.1.0) | 2026-07-18 (a week ago) |

### Release notes

<details>
<summary><code>boltons</code></summary>

#### [`26.1.0`](https://github.com/mahmoud/boltons/releases/tag/26.1.0)

- Fixed `strutils.singularize` mangling words ending in 'ss'
- Fixed `fileutils.AtomicSaver` to accept `os.PathLike`
- Fixed `copy.copy`/`copy.deepcopy` collapsing `dictutils.OrderedMultiDict` values
- Sped up `strutils.MultiReplace` match lookup
- Fixed `setutils.IndexedSet` out-of-range negative indexing wrapping around
- Fixed `setutils.IndexedSet` slicing after removals

**Full Changelog**: https://redirect.github.com/mahmoud/boltons/compare/26.0.0...26.1.0

</details>

<details>
<summary><code>extra-platforms</code></summary>

#### [`v13.3.1`](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.3.1)

> [!NOTE]
> `13.3.1` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/13.3.1/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v13.3.1).

- Fix `test_current_funcs` failing under nested shells: extra shells backed by real ancestor processes (like a fish session running an OBS chroot build) are now accounted for. Addresses [#​619](https://redirect.github.com/kdeldycke/extra-platforms/issues/619)
- Document detection semantics on every trait page: which traits can match simultaneously (shells, platforms, terminals), which are exclusive (architectures, CI systems, agents), and how each `current_*()` function arbitrates or reports absences.
- Skip the whole test workflow on version-bump pushes and pull requests.
- Skip the package install checks on pull requests: they exercise the released package, not the change under review.
- Run the test suite in parallel outside CI too, by moving `--numprocesses=auto` and `--dist=loadgroup` to pytest `addopts`.

**Full changelog**: [`v13.3.0...v13.3.1`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v13.3.0...v13.3.1)

</details>

<details>
<summary><code>platformdirs</code></summary>

#### [`4.10.1`](https://github.com/tox-dev/platformdirs/releases/tag/4.10.1)

<!-- Release notes generated using configuration in .github/release.yaml at 4.10.1 -->

##### What's Changed
* 🐛 fix(windows): stop leaking memory on repeated folder lookups by @​gaborbernat in https://redirect.github.com/tox-dev/platformdirs/pull/507
* 🚀 ci(release): towncrier changelog + publish on tag push by @​gaborbernat in https://redirect.github.com/tox-dev/platformdirs/pull/509
* 📝 docs(changelog): rebuild against release history by @​gaborbernat in https://redirect.github.com/tox-dev/platformdirs/pull/510

**Full Changelog**: https://redirect.github.com/tox-dev/platformdirs/compare/4.10.0...4.10.1

</details>

<details>
<summary><code>soupsieve</code></summary>

#### [`2.9`](https://github.com/facelessuser/soupsieve/releases/tag/2.9)

##### 2.9

-   **NEW**: Drop Python 3.9 support.
-   **NEW**: Lazy compile selector patterns to improve initial import speed.
-   **FIX**: Correct `:nth-child`/`:nth-of-type` (and `-last-` variants) for `An+B` values whose sequence steps onto
    index 0 or onto the last child (e.g. `:nth-child(2n-2)`, `:nth-child(n-1)`, `:nth-child(n+5)`), which previously
    matched the wrong elements or nothing at all (@​gaoflow).
-   **FIX**: More efficient CSS ID matching (@​kaimandalic).
-   **FIX**: Fix inefficient trimming of comments and white space (@​kaimandalic).

</details>

<details>
<summary><code>sphinxcontrib-mermaid</code></summary>

[Changelog](https://redirect.github.com/mgaitan/sphinxcontrib-mermaid/blob/master/CHANGELOG.md)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [bracex](https://pypi.org/project/bracex/) | `3.0` | `3.0.1` | 2026-07-20 (6 days ago) | 2026-07-27 (in a day) |
| [certifi](https://pypi.org/project/certifi/) | `2026.6.17` | `2026.7.22` | 2026-07-22 (4 days ago) | 2026-07-29 (in 3 days) |
| [platformdirs](https://pypi.org/project/platformdirs/) | `4.10.1` | `4.11.0` | 2026-07-21 (5 days ago) | 2026-07-28 (in 2 days) |
| [soupsieve](https://pypi.org/project/soupsieve/) | `2.9` | `2.9.1` | 2026-07-21 (5 days ago) | 2026-07-28 (in 2 days) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | `3.12.1` | `3.13.0` | 2026-07-21 (5 days ago) | 2026-07-28 (in 2 days) |
| [types-boltons](https://pypi.org/project/types-boltons/) | `25.0.0.20260612` | `26.1.0.20260724` | 2026-07-24 (2 days ago) | 2026-07-31 (in 5 days) |
| [types-docutils](https://pypi.org/project/types-docutils/) | `0.22.3.20260712` | `0.22.3.20260724` | 2026-07-24 (2 days ago) | 2026-07-31 (in 5 days) |
| [types-pyyaml](https://pypi.org/project/types-pyyaml/) | `6.0.12.20260518` | `6.0.12.20260724` | 2026-07-24 (2 days ago) | 2026-07-31 (in 5 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://kdeldycke.github.io/repomatic/workflows.html#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`be6e3706`](https://github.com/kdeldycke/click-extra/commit/be6e37066bcd6922dd49ff777bb831e96d73748b)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/click-extra/blob/be6e37066bcd6922dd49ff777bb831e96d73748b/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/be6e37066bcd6922dd49ff777bb831e96d73748b/.github/workflows/autofix.yaml)
- **Run**: [#3080.1](https://github.com/kdeldycke/click-extra/actions/runs/30207855222)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.3.0`