### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -96,11 +96,11 @@ wheels = [
 
 [[package]]
 name = "bracex"
-version = "3.0"
+version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d0/f5/4473ad9b48cd0420a2d762a3750fa0e078e23e060b1af72662e5987e5530/bracex-3.0.tar.gz", hash = "sha256:b73f718d6bd98d8419e45df02426c86e9967c179949f779340d6c3a8c83b9111", size = 43162, upload-time = "2026-06-30T00:43:35.279Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/01/5f394b8bcd6e5b92f73130990960423bbb19711f906bd9fe9ea5557c667c/bracex-3.0.1.tar.gz", hash = "sha256:4e38e32392e4a4780fe15d644bfc7c8514057cfc3861e060b11814ce829c25e4", size = 44019, upload-time = "2026-07-20T13:43:00.335Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/2e/68781b78e764e5ccc4af1e3d27e060069c73af90234853fa80000e7ee79d/bracex-3.0-py3-none-any.whl", hash = "sha256:3833e61c2f092d5aa0468fa2e6c6e990a306185abf763b6d122f0158e59c58a5", size = 11738, upload-time = "2026-06-30T00:43:34.196Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/8f/6f7273a7adb8d73fc8d21ede4376a3e475e52f98435c6007f69100dec8ca/bracex-3.0.1-py3-none-any.whl", hash = "sha256:6523ad83aeb5098a4ee597cff0f964442ff74e460bd3fafaffab6a013ff2288c", size = 11940, upload-time = "2026-07-20T13:42:59.268Z" },
 ]
 
 [[package]]
@@ -593,11 +593,11 @@ wheels = [
 
 [[package]]
 name = "extra-platforms"
-version = "13.4.0"
+version = "13.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/be/e3/b04ca89a5b48424fc7df7dc4131ea4ffd8efa8788590163c2f777a02b959/extra_platforms-13.4.0.tar.gz", hash = "sha256:d3d07e1afeaa9cdd9c6c4b716e81c2b18c7af1b6d68c157c1b339b31f6597903", size = 465364, upload-time = "2026-07-27T05:57:56.714Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/bc/8076e2ab0c6c45366d85ede5008aa44b4931a7020cd420907407762d27fa/extra_platforms-13.5.0.tar.gz", hash = "sha256:03125bc6dfe692ab658cce5eabe35dad993e9e84e5af4c526ae087499ee6f17c", size = 465427, upload-time = "2026-07-27T13:34:20.238Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/85/ad68e8005e13f6aef1a30fa7e535266815a62d3da44797618703d6a6bc23/extra_platforms-13.4.0-py3-none-any.whl", hash = "sha256:1e96d0b016f7c9cd85f682cf8fe43a1148780a00e4aa284e65937a16e8d1b927", size = 90892, upload-time = "2026-07-27T05:57:54.921Z" },
+    { url = "https://files.pythonhosted.org/packages/87/d6/818228b1c13cb04b8575eb08ce0d4f729544d58b59fc1625ef1c748b9d84/extra_platforms-13.5.0-py3-none-any.whl", hash = "sha256:046647a4b0ba82aa84dff207d8149d20afe278ed65fb690eb68ec1611eecf8a9", size = 91124, upload-time = "2026-07-27T13:34:18.421Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-07-20`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [bracex](https://pypi.org/project/bracex/) | [`3.0` → `3.0.1`](https://github.com/facelessuser/bracex/compare/3.0...3.0.1) | 2026-07-20 (a week ago) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | [`13.4.0` → `13.5.0`](https://github.com/kdeldycke/extra-platforms/compare/v13.4.0...v13.5.0) | 2026-07-27 (just now) |

### Release notes

<details>
<summary><code>bracex</code></summary>

#### [`3.0.1`](https://github.com/facelessuser/bracex/releases/tag/3.0.1)

##### 3.0.1

-   **FIX**: Fix case where character or number ranges could throw an exception (@​santhreal).

</details>

<details>
<summary><code>extra-platforms</code></summary>

#### [`v13.5.0`](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.5.0)

> [!NOTE]
> `13.5.0` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/13.5.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v13.5.0).

- Rename the `GUIX_BUILD` CI trait to `HERMETIC_BUILD`. `GUIX_BUILD`, `is_guix_build()` and the `skip_guix_build`/`unless_guix_build` decorators still resolve to their `HERMETIC_BUILD` counterparts with a `DeprecationWarning`, and will be removed in `14.0.0`.

**Full changelog**: [`v13.4.0...v13.5.0`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v13.4.0...v13.5.0)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [certifi](https://pypi.org/project/certifi/) | `2026.6.17` | `2026.7.22` | 2026-07-22 (5 days ago) | 2026-07-29 (in 2 days) |
| [platformdirs](https://pypi.org/project/platformdirs/) | `4.10.1` | `4.11.0` | 2026-07-21 (6 days ago) | 2026-07-28 (in a day) |
| [soupsieve](https://pypi.org/project/soupsieve/) | `2.9` | `2.9.1` | 2026-07-21 (6 days ago) | 2026-07-28 (in a day) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | `3.12.1` | `3.13.0` | 2026-07-21 (6 days ago) | 2026-07-28 (in a day) |
| [types-boltons](https://pypi.org/project/types-boltons/) | `25.0.0.20260612` | `26.1.0.20260724` | 2026-07-24 (3 days ago) | 2026-07-31 (in 4 days) |
| [types-docutils](https://pypi.org/project/types-docutils/) | `0.22.3.20260712` | `0.22.3.20260724` | 2026-07-24 (3 days ago) | 2026-07-31 (in 4 days) |
| [types-pyyaml](https://pypi.org/project/types-pyyaml/) | `6.0.12.20260518` | `6.0.12.20260724` | 2026-07-24 (3 days ago) | 2026-07-31 (in 4 days) |

## ❄️ Cooldown bypasses

Packages pulled in ahead of the cooldown by an [`exclude-newer-package`](https://docs.astral.sh/uv/reference/settings/#exclude-newer-package) freeze. Each entry is cleared from `pyproject.toml` automatically once its held version ages past the `exclude-newer` cutoff.

| Package | Held at | Held until |
| :-- | :-- | :-- |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.5.0` | 2026-08-03 (in a week) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://kdeldycke.github.io/repomatic/workflows.html#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`6755c1c9`](https://github.com/kdeldycke/click-extra/commit/6755c1c92c59e2a3266913e1ab75bcf8e19fd56a)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/click-extra/blob/6755c1c92c59e2a3266913e1ab75bcf8e19fd56a/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/6755c1c92c59e2a3266913e1ab75bcf8e19fd56a/.github/workflows/autofix.yaml)
- **Run**: [#3088.1](https://github.com/kdeldycke/click-extra/actions/runs/30283806308)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.3.0`