### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -593,11 +593,11 @@ wheels = [
 
 [[package]]
 name = "extra-platforms"
-version = "13.5.0"
+version = "13.5.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dc/bc/8076e2ab0c6c45366d85ede5008aa44b4931a7020cd420907407762d27fa/extra_platforms-13.5.0.tar.gz", hash = "sha256:03125bc6dfe692ab658cce5eabe35dad993e9e84e5af4c526ae087499ee6f17c", size = 465427, upload-time = "2026-07-27T13:34:20.238Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/4d/85b286ccdffdb9c93f537428dbab9616f15f89ed40f9217ac21bc21e01b6/extra_platforms-13.5.1.tar.gz", hash = "sha256:89100acdf8aa28f8c589981b653e9f42a5bd68ce932c33cbd6faa7a81731c7c6", size = 465562, upload-time = "2026-07-27T19:28:20.5Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/d6/818228b1c13cb04b8575eb08ce0d4f729544d58b59fc1625ef1c748b9d84/extra_platforms-13.5.0-py3-none-any.whl", hash = "sha256:046647a4b0ba82aa84dff207d8149d20afe278ed65fb690eb68ec1611eecf8a9", size = 91124, upload-time = "2026-07-27T13:34:18.421Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/03/4d65c1bb5064cc895bac491ee34e50a23058dc5b80e718e9f4ad386c7eb4/extra_platforms-13.5.1-py3-none-any.whl", hash = "sha256:b6fd87f13933a19f073eb329848b0722c8037b657bc519befc19cdd56384a5bc", size = 91123, upload-time = "2026-07-27T19:28:18.606Z" },
 ]
 
 [package.optional-dependencies]
@@ -1024,11 +1024,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.10.1"
+version = "4.11.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/52/cd/4f25b2f95b23f5d2c9c1fe43e49841bff5800562149b2666afc09309aa8f/platformdirs-4.10.1.tar.gz", hash = "sha256:ceab4084426fe6319ce18e86deada8ab1b7487c7aee7040c55e277c9ae793695", size = 31678, upload-time = "2026-07-18T03:53:43.808Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/9b/560e4be8e26f6fd133a03630a8df0c663b9e8d61b4ade152b72005aec83b/platformdirs-4.11.0.tar.gz", hash = "sha256:0555d18370482847566ffabcaa53ad7c6c1c29f195989ae1ed634a05f76ea1e0", size = 31953, upload-time = "2026-07-21T13:09:36.565Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/73/6fd0bb9ce84138c3857f12e9de63bc901852975a092d545f18087a204aa2/platformdirs-4.10.1-py3-none-any.whl", hash = "sha256:0e4eff26be2d75293977f7cddc153fd9b8eaa7fb0c7b64ffe4076cb443117443", size = 22906, upload-time = "2026-07-18T03:53:42.576Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/68/d8d58938dfb1370b266a1a729e6d77a985be23689a0496498ee17b2cbf90/platformdirs-4.11.0-py3-none-any.whl", hash = "sha256:360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74", size = 23247, upload-time = "2026-07-21T13:09:35.422Z" },
 ]
 
 [[package]]
@@ -1530,11 +1530,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.9"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/80/f1/93422647dd7e461f23d254e6b2bfa687a85b53aeb4903fcdbb74474d4584/soupsieve-2.9.tar.gz", hash = "sha256:acee8417325c5653e1377dc31eccad59eb82cbc65942afe6174c53b3aaad63fc", size = 122122, upload-time = "2026-07-19T01:35:18.425Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/38/e12680bbe6b4f8f3d17adcaf38d26850aa756c85cf4a80e79fc12a018fe8/soupsieve-2.9.1.tar.gz", hash = "sha256:c33e6605bbc71dd628b00c632d58ae607c22bade247e52553928f83bbb75b4ba", size = 122261, upload-time = "2026-07-21T16:57:17.452Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/d6/3185ab5ad1280319b31986898f3206dd7227cd75e293d4dba2a5e6bf27a0/soupsieve-2.9-py3-none-any.whl", hash = "sha256:a2b2c76d67df2382d245409fd71e321a571717e58463efa32ace87dcadac2c12", size = 37387, upload-time = "2026-07-19T01:35:17.106Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/2c/437fe806897c2d6cfdc3ee43a18da8bf8e568530a4ae9bac781541ca9896/soupsieve-2.9.1-py3-none-any.whl", hash = "sha256:4f4477399246b7a0c720a88ca2454b11cd6bb9ae4c9d170140786e916776c14c", size = 37404, upload-time = "2026-07-21T16:57:16.421Z" },
 ]
 
 [[package]]
@@ -1633,14 +1633,14 @@ wheels = [
 
 [[package]]
 name = "sphinx-autodoc-typehints"
-version = "3.12.1"
+version = "3.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" } },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/ae/8ad5e79a0f7beac5e5810b2a8d0a1c6c63c795ba265a81970070abf15f32/sphinx_autodoc_typehints-3.12.1.tar.gz", hash = "sha256:4bbf6f6b907586d3b2a3ae2b23e0f86be939f19a7449e917d304df57ff9674d1", size = 84421, upload-time = "2026-07-03T13:52:09.056Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/99/e5a23a7bc3f9b6b799dbf72ab3955cdc0b2382803b5d11eaafcc76621662/sphinx_autodoc_typehints-3.13.0.tar.gz", hash = "sha256:59eb4fe26f71ccd7a8f10caadddcb3c3b31df7016f91bda546da2a333bae4e12", size = 85285, upload-time = "2026-07-21T13:10:44.981Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/a2/d5964523f0c98e39ef608a09f3de23032aa32fbe3e98a262e2112c39f985/sphinx_autodoc_typehints-3.12.1-py3-none-any.whl", hash = "sha256:932472c9cc160e6a0dc34eca13d3d6a9823ed6e6dc505d7c12f6963c983cf8f6", size = 42950, upload-time = "2026-07-03T13:52:07.696Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1c/4b3c9b1a3130b9d717f517351ce8325a62fad7c4f846cc324025c22a43c6/sphinx_autodoc_typehints-3.13.0-py3-none-any.whl", hash = "sha256:d71c388c865f3bedc1f32416febb0f8886b3051a4cd8bd8677e64b8b65c9b475", size = 43440, upload-time = "2026-07-21T13:10:43.793Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-07-21`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | [`13.5.0` → `13.5.1`](https://github.com/kdeldycke/extra-platforms/compare/v13.5.0...v13.5.1) | 2026-07-27 (a day ago) |
| [platformdirs](https://pypi.org/project/platformdirs/) | [`4.10.1` → `4.11.0`](https://github.com/tox-dev/platformdirs/compare/4.10.1...4.11.0) | 2026-07-21 (a week ago) |
| [soupsieve](https://pypi.org/project/soupsieve/) | [`2.9` → `2.9.1`](https://github.com/facelessuser/soupsieve/compare/2.9...2.9.1) | 2026-07-21 (a week ago) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | [`3.12.1` → `3.13.0`](https://github.com/tox-dev/sphinx-autodoc-typehints/compare/3.12.1...3.13.0) | 2026-07-21 (a week ago) |

### Release notes

<details>
<summary><code>extra-platforms</code></summary>

#### [`v13.5.1`](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.5.1)

> [!NOTE]
> `13.5.1` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/13.5.1/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v13.5.1).

- Skip `test_github_runner_detection` unless `EXTRA_PLATFORMS_TEST_MATRIX` is set, instead of whenever GitHub CI is detected, so downstream packagers building the test suite inside GitHub Actions no longer fail on the absent matrix variable.

**Full changelog**: [`v13.5.0...v13.5.1`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v13.5.0...v13.5.1)

</details>

<details>
<summary><code>platformdirs</code></summary>

#### [`4.11.0`](https://github.com/tox-dev/platformdirs/releases/tag/4.11.0)

<!-- Release notes generated using configuration in .github/release.yaml at 4.11.0 -->

##### What's Changed
* 👷 ci: run the test suite against Python 3.15 by @​gaborbernat in https://redirect.github.com/tox-dev/platformdirs/pull/512

**Full Changelog**: https://redirect.github.com/tox-dev/platformdirs/compare/4.10.1...4.11.0

</details>

<details>
<summary><code>soupsieve</code></summary>

#### [`2.9.1`](https://github.com/facelessuser/soupsieve/releases/tag/2.9.1)

##### 2.9.1

-   **FIX**: Correct `[attr^=""]`, `[attr$=""]`, and `[attr*=""]` to match nothing when the value is empty, per CSS
    Selectors Level 4 substring matching, which previously matched any element merely having the attribute
    (@​chuenchen309).

</details>

<details>
<summary><code>sphinx-autodoc-typehints</code></summary>

#### [`3.13.0`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.13.0)

<!-- Release notes generated using configuration in .github/release.yaml at 39e9e1c470479e83e21553d074bd03ad9c90645f -->

##### What's Changed
* Replace prettier with mdformat and yamlfmt by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/733
* 👷 ci(python): test against Python 3.15 beta by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/735

**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.11.1...3.13.0

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [certifi](https://pypi.org/project/certifi/) | `2026.6.17` | `2026.7.22` | 2026-07-22 (6 days ago) | 2026-07-29 (in a day) |
| [types-boltons](https://pypi.org/project/types-boltons/) | `25.0.0.20260612` | `26.1.0.20260724` | 2026-07-24 (4 days ago) | 2026-07-31 (in 3 days) |
| [types-docutils](https://pypi.org/project/types-docutils/) | `0.22.3.20260712` | `0.22.3.20260724` | 2026-07-24 (4 days ago) | 2026-07-31 (in 3 days) |
| [types-pygments](https://pypi.org/project/types-pygments/) | `2.20.0.20260518` | `2.20.0.20260728` | 2026-07-28 (just now) | 2026-08-04 (in a week) |
| [types-pyyaml](https://pypi.org/project/types-pyyaml/) | `6.0.12.20260518` | `6.0.12.20260724` | 2026-07-24 (4 days ago) | 2026-07-31 (in 3 days) |

## ❄️ Cooldown bypasses

Packages pulled in ahead of the cooldown by an [`exclude-newer-package`](https://docs.astral.sh/uv/reference/settings/#exclude-newer-package) freeze. Each entry is cleared from `pyproject.toml` automatically once its held version ages past the `exclude-newer` cutoff.

| Package | Held at | Held until |
| :-- | :-- | :-- |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.5.1` | 2026-08-03 (in 6 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://kdeldycke.github.io/repomatic/workflows.html#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`018c75bd`](https://github.com/kdeldycke/click-extra/commit/018c75bd687226e4db9d44cc31a8106059316329)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/click-extra/blob/018c75bd687226e4db9d44cc31a8106059316329/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/018c75bd687226e4db9d44cc31a8106059316329/.github/workflows/autofix.yaml)
- **Run**: [#3095.1](https://github.com/kdeldycke/click-extra/actions/runs/30397220012)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.3.0`