### PR TITLE
Sync action pins

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,7 +59,7 @@ jobs:
       metadata: ${{ steps.metadata.outputs.metadata }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Run repomatic metadata
         id: metadata
         run: >
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Install Python
         run: uv --no-progress venv --python 3.14
       - name: Install project
@@ -138,7 +138,7 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-slim
     steps:
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Install Python
         run: uv --no-progress venv --python 3.14
 
@@ -208,7 +208,7 @@ jobs:
     continue-on-error: ${{ matrix.state == 'unstable' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Force native ARM64 Python on Windows ARM64
         # Workaround for https://github.com/astral-sh/uv/issues/12906: uv defaults to x86_64 Python on ARM64 Windows,
         # relying on transparent emulation. Native extensions with Rust (e.g., test-results-parser from codecov-cli)


### PR DESCRIPTION
## 🆙 Updated actions

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `7 days`: releases after `2026-07-21` are held back.

| Action | Change | Released |
| :-- | :-- | :-- |
| [astral-sh/setup-uv](https://github.com/astral-sh/setup-uv) | [`v8.3.2` → `v9.0.0`](https://github.com/astral-sh/setup-uv/compare/v8.3.2...v9.0.0) | 2026-07-21 (a week ago) |

### Release notes

<details>
<summary><code>astral-sh/setup-uv</code></summary>

#### [`v9.0.0`](https://github.com/astral-sh/setup-uv/releases/tag/v9.0.0)

##### Changes

This release disables the default cache cache pruning to ease the load on the PyPi infrastructure.
Since users might experience more GitHub Actions cache usage which might result in higher costs this is marked as a breaking change. To read more on why we did this (now) you can read the detailed analysis and reasoning in #​967

Besides this big breaking change we also have a small bugfix while building caches for linux distributions that behave a big different than the "big ones" and a speed up in version resolution by only reading the version manifest until a matching version is found saving runtime and network bandwith.

##### 🚨 Breaking changes

- Change `prune-cache` default to `false` @​charliermarsh (#​967)

##### 🐛 Bug fixes

- fix: fall back to distribution ID when os-release has no version field @​cxzhong (#​961)

##### 🚀 Enhancements

- Speed up version client by partial response reads @​eifinger (#​807)

##### 🧰 Maintenance

- chore: update known checksums for 0.11.30 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​968)
- chore: update known checksums for 0.11.29 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​960)

##### 📚 Documentation

- docs: update version references to v8.3.2 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​949)

##### ⬆️ Dependency updates

- chore(deps): roll up Dependabot updates @​eifinger (#​970)
- chore(deps): roll up Dependabot updates @​eifinger (#​962)

</details>

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`action-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#action-pins-sync)
- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-action-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-action-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`018c75bd`](https://github.com/kdeldycke/click-extra/commit/018c75bd687226e4db9d44cc31a8106059316329)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/click-extra/blob/018c75bd687226e4db9d44cc31a8106059316329/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/018c75bd687226e4db9d44cc31a8106059316329/.github/workflows/autofix.yaml)
- **Run**: [#3095.1](https://github.com/kdeldycke/click-extra/actions/runs/30397220012)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.3.0`