### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Run repomatic metadata
         id: metadata
         run: >
-          uvx --no-progress 'repomatic==7.3.0' metadata
+          uvx --no-progress 'repomatic==7.3.1' metadata
           --format github-json --output "$GITHUB_OUTPUT"
           coverage_cells test_matrix test_matrix_pr
 


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `7 days`: releases after `2026-07-22` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [repomatic](https://pypi.org/project/repomatic/) | `7.3.0` → `7.3.1` | [⛓️ lockstep with `uses:` refs](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater) |

### Release notes

<details>
<summary><code>repomatic</code></summary>

#### [`v7.3.1`](https://github.com/kdeldycke/repomatic/releases/tag/v7.3.1)

> [!NOTE]
> `7.3.1` is available on [🐍 PyPI](https://pypi.org/project/repomatic/7.3.1/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/repomatic/releases/tag/v7.3.1).

- Refresh the bundled pytest defaults to the canonical configuration: `importlib` import mode, `tests/`-restricted collection, the `once` marker, parallel runs via `pytest-xdist`, and `--cov-report=xml` left to the test workflow's command line.
- Mark the `validate-arch` job of `tests.yaml` as canonical-repository-only: downstream repos drop the job and its `build_targets` metadata field when adapting the workflow.
- Point the `lint-changelog` `not found on PyPI` warning at its remedy: list intentionally-unpublished releases under `[tool.repomatic] abandoned-versions`.
- Fix the post-release re-trigger of `changelog.yaml`: its `workflow_run` filter still watched the pre-emoji `Build & release` workflow name and never fired.
- Fix `lint-changelog --fix` treating a published pre-release (`X.Y.Z.dev0`, `rc`, `alpha`, `beta`) as a missing changelog entry, which inserted a spurious section and rewrote the adjacent release's comparison URL.
- Fix the `update-docs` autofix job opening a duplicate of the `format-pyproject` pull request: it now reformats `pyproject.toml` only when `update-docs` changed it.
- Skip the bare `uvx <script>` invocation of the package-install smoke job when the CLI script is not named after its package.
- Restructure the `repomatic-ship` skill: rules shared by every spawned agent move to a single section, and accumulated incident notes compress into their operative rules.
- Harden the `repomatic-ship` release checks: dispatch `release.yaml` past a content-skipped binary matrix, revert formatter moves whole, read the freeze scope from the regenerated release PR, and verify `{click:run}` blocks against the live CLI.
- Direct the `repomatic-ship` docs pass to advance version samples lagging the released tag up to it.

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v7.3.1)

</details>

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`21a4b80e`](https://github.com/kdeldycke/click-extra/commit/21a4b80ee9361dbd731da210a19399de7743b19f)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/click-extra/blob/21a4b80ee9361dbd731da210a19399de7743b19f/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/21a4b80ee9361dbd731da210a19399de7743b19f/.github/workflows/autofix.yaml)
- **Run**: [#3100.1](https://github.com/kdeldycke/click-extra/actions/runs/30484963101)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.3.1`