### PR TITLE
Bump minor version to `v8.9.0`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [`8.8.2.dev0` (unreleased)](https://github.com/kdeldycke/click-extra/compare/v8.8.1...main)
+## [`8.9.0.dev0` (unreleased)](https://github.com/kdeldycke/click-extra/compare/v8.8.1...main)
 
 > [!WARNING]
 > This version is **not released yet** and is under active development.

--- a/citation.cff
+++ b/citation.cff
@@ -8,8 +8,8 @@ authors:
     email: kevin@deldycke.com
     orcid: "https://orcid.org/0000-0001-9748-9014"
 doi: 10.5281/zenodo.7116050
-version: 8.8.2.dev0
+version: 8.9.0.dev0
 # The release date is kept up to date by the external workflows. See:
 # https://github.com/kdeldycke/workflows/blob/33b704b489c1aa18b7b7efbf963e153e91e1c810/.github/workflows/changelog.yaml#L135-L137
-date-released: 2026-08-02
+date-released: 2026-08-11
 url: "https://github.com/kdeldycke/click-extra"

--- a/click_extra/__init__.py
+++ b/click_extra/__init__.py
@@ -570,7 +570,7 @@ _scrub_foreign_modules()
 del _scrub_foreign_modules
 
 
-__version__ = "8.8.2.dev0"
+__version__ = "8.9.0.dev0"
 __git_branch__ = ""
 __git_date__ = ""
 __git_long_hash__ = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "uv-build>=0.8" ]
 [project]
 # Docs: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
 name = "click-extra"
-version = "8.8.2.dev0"
+version = "8.9.0.dev0"
 description = "🌈 Drop-in replacement for Click to make user-friendly and colorful CLI"
 readme = "readme.md"
 keywords = [
@@ -204,7 +204,7 @@ click-extra = "click_extra.__main__:main"
 
 [project.urls]
 "Homepage" = "https://github.com/kdeldycke/click-extra"
-"Download" = "https://github.com/kdeldycke/click-extra/releases/tag/v8.8.2.dev0"
+"Download" = "https://github.com/kdeldycke/click-extra/releases/tag/v8.9.0.dev0"
 "Changelog" = "https://github.com/kdeldycke/click-extra/blob/main/changelog.md"
 "Issues" = "https://github.com/kdeldycke/click-extra/issues"
 "Repository" = "https://github.com/kdeldycke/click-extra"
@@ -470,7 +470,7 @@ report.precision = 2
 file = "tests/cli-test-suite.toml"
 
 [tool.bumpversion]
-current_version = "8.8.2.dev0"
+current_version = "8.9.0.dev0"
 # Parse versions with an optional .devN suffix (PEP 440).
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(\\.dev(?P<dev>\\d+))?"
 serialize = [

--- a/uv.lock
+++ b/uv.lock
@@ -210,7 +210,7 @@ wheels = [
 
 [[package]]
 name = "click-extra"
-version = "8.8.2.dev0"
+version = "8.9.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "boltons" },


### PR DESCRIPTION
Ready to be merged into `main` branch, at the discretion of the maintainers, to bump the minor part of the version number. Version bumps are scheduled daily and also triggered after releases. See the [`bump-version` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-changelog-yaml-jobs) for details.

## To bump version to `v8.9.0`

1. **Click `Ready for review`** button below, to get this PR out of `Draft` mode

2. **Click `Rebase and merge`** button below


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`bump-version`](https://kdeldycke.github.io/repomatic/workflows.html#bump-version-bump-version)
- **Trigger**: `workflow_run`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`8ac9c0b5`](https://github.com/kdeldycke/click-extra/commit/8ac9c0b5ba54665dec755dd11d2f5dfe6870fd45)
- **Job**: [`bump-version`](https://github.com/kdeldycke/click-extra/blob/8ac9c0b5ba54665dec755dd11d2f5dfe6870fd45/.github/workflows/changelog.yaml)
- **Workflow**: [`changelog.yaml`](https://github.com/kdeldycke/click-extra/blob/8ac9c0b5ba54665dec755dd11d2f5dfe6870fd45/.github/workflows/changelog.yaml)
- **Run**: [#1748.1](https://github.com/kdeldycke/click-extra/actions/runs/31469913628)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.4.1`