### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1630,14 +1630,14 @@ wheels = [
 
 [[package]]
 name = "sphinx-autodoc-typehints"
-version = "3.13.1"
+version = "3.13.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" } },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/2a/4907187acada80fc201e0ef85daf79027de8c85150d183d04de5328f928c/sphinx_autodoc_typehints-3.13.1.tar.gz", hash = "sha256:13c89cd0260b98b416563fa88419f006a355e54309df3e990896d622d84045ca", size = 86587, upload-time = "2026-08-03T16:43:17.533Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/5f/7f2a768683c24dac122d6d9714b923ed84d87ffde058a37d525996687295/sphinx_autodoc_typehints-3.13.2.tar.gz", hash = "sha256:ea20b9a217b86391b0ece262c4336e3c2f476fe1f76028635d550b4e74cd7498", size = 88492, upload-time = "2026-08-03T22:26:01.344Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/eb/368138dceca20ed6cc5181932c1812a375cc75220f779cff6c50a467af31/sphinx_autodoc_typehints-3.13.1-py3-none-any.whl", hash = "sha256:2ceddadc3d733cbaf1ca4279cc3a1a7976e6f7864e9ca4dd5e3f170e212fbaa4", size = 43950, upload-time = "2026-08-03T16:43:16.302Z" },
+    { url = "https://files.pythonhosted.org/packages/97/53/7ae6f44d2a9275562ff6fb7cf8be14c35e8ab057ebd4954f9f10558efb0d/sphinx_autodoc_typehints-3.13.2-py3-none-any.whl", hash = "sha256:b2a7b531369a128c7c52867962fe224d89a1d480a462a314621c710a7d6e3ecf", size = 44836, upload-time = "2026-08-03T22:26:00.029Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-08-04`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | [`3.13.1` → `3.13.2`](https://github.com/tox-dev/sphinx-autodoc-typehints/compare/3.13.1...3.13.2) | 2026-08-03 (a week ago) |

### Release notes

<details>
<summary><code>sphinx-autodoc-typehints</code></summary>

#### [`3.13.2`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.13.2)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

##### What's Changed
* fix: support subscripted type aliases by @​flying-sheep in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/745


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.13.1...3.13.2

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [coverage](https://pypi.org/project/coverage/) | `7.15.3` | `7.15.4` | 2026-08-06 (5 days ago) | 2026-08-13 (in 2 days) |
| [packaging](https://pypi.org/project/packaging/) | `26.2` | `26.3` | 2026-08-04 (a week ago) | 2026-08-11 (just now) |
| [platformdirs](https://pypi.org/project/platformdirs/) | `4.11.0` | `4.11.2` | 2026-08-10 (a day ago) | 2026-08-17 (in 6 days) |
| [soupsieve](https://pypi.org/project/soupsieve/) | `2.9.1` | `2.9.2` | 2026-08-07 (4 days ago) | 2026-08-14 (in 3 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://kdeldycke.github.io/repomatic/workflows.html#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`8ac9c0b5`](https://github.com/kdeldycke/click-extra/commit/8ac9c0b5ba54665dec755dd11d2f5dfe6870fd45)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/click-extra/blob/8ac9c0b5ba54665dec755dd11d2f5dfe6870fd45/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/8ac9c0b5ba54665dec755dd11d2f5dfe6870fd45/.github/workflows/autofix.yaml)
- **Run**: [#3148.1](https://github.com/kdeldycke/click-extra/actions/runs/31466277376)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.4.1`