### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.12.1"
+          version: "0.12.2"
       - name: Run repomatic metadata
         id: metadata
         # The `--exclude-newer-package` flag is not optional: the workflow-level
@@ -100,7 +100,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.12.1"
+          version: "0.12.2"
       - name: Install Python
         run: uv --no-progress venv --python 3.14
       - name: Install project
@@ -156,7 +156,7 @@ jobs:
     steps:
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.12.1"
+          version: "0.12.2"
       - name: Install Python
         run: uv --no-progress venv --python 3.14
 
@@ -228,7 +228,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.12.1"
+          version: "0.12.2"
       - name: Force native ARM64 Python on Windows ARM64
         # Workaround for https://github.com/astral-sh/uv/issues/12906: uv defaults to x86_64 Python on ARM64 Windows,
         # relying on transparent emulation, so an ARM64 Windows cell would silently test emulated x86_64 Python


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `7 days`: releases after `2026-08-07` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [uv](https://pypi.org/project/uv/) | `0.12.1` → `0.12.2` | 2026-08-05 (a week ago) |

### Release notes

<details>
<summary><code>uv</code></summary>

#### [`0.12.2`](https://github.com/astral-sh/uv/releases/tag/0.12.2)

##### Release Notes

Released on 2026-08-05.

###### Python

- Add CPython 3.15.0rc1 ([#​20948](https://redirect.github.com/astral-sh/uv/pull/20948))
- Add CPython 3.14.7 ([#​20971](https://redirect.github.com/astral-sh/uv/pull/20971))

###### Enhancements

- Ensure diagnostic hints end with a newline to prevent malformed terminal output ([#​20959](https://redirect.github.com/astral-sh/uv/pull/20959))

###### Preview features

- Audit one or all installed tools with `uv tool audit` ([#​20921](https://redirect.github.com/astral-sh/uv/pull/20921))
- Report physically reclaimed disk space during cache cleanup with the `cache-physical-space` preview feature ([#​20925](https://redirect.github.com/astral-sh/uv/pull/20925))

###### Configuration

- Add `UV_RUN_RLIMIT_NOFILE` to set the open-file limit for commands launched by `uv run` ([#​20926](https://redirect.github.com/astral-sh/uv/pull/20926))

###### Performance

- Speed up `uv.lock` parsing for wheel entries ([#​20881](https://redirect.github.com/astral-sh/uv/pull/20881))
- Speed up `uv.lock` parsing for source distribution entries ([#​20882](https://redirect.github.com/astral-sh/uv/pull/20882))
- Speed up filename extraction from distribution URLs ([#​20879](https://redirect.github.com/astral-sh/uv/pull/20879))
- Reduce filesystem metadata lookups during bytecode compilation ([#​20928](https://redirect.github.com/astral-sh/uv/pull/20928))
- Reuse file metadata when building source distributions ([#​20927](https://redirect.github.com/astral-sh/uv/pull/20927))

###### Bug fixes

- Preserve compatibility with older uv versions when recording artifact sizes in cached wheels and source distributions ([#​20963](https://redirect.github.com/astral-sh/uv/pull/20963))
- Avoid including workspace-root default dependency groups when syncing or exporting a selected workspace member unless explicitly requested ([#​20930](https://redirect.github.com/astral-sh/uv/pull/20930))

###### Documentation

... [Full release notes](https://github.com/astral-sh/uv/releases/tag/0.12.2)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [uv](https://pypi.org/project/uv/) | `0.12.2` | `0.12.4` | 2026-08-13 (a day ago) | 2026-08-20 (in 6 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`688cd53a`](https://github.com/kdeldycke/click-extra/commit/688cd53a98589ac7b4f4dabcf166e9f1627e94e4)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/click-extra/blob/688cd53a98589ac7b4f4dabcf166e9f1627e94e4/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/688cd53a98589ac7b4f4dabcf166e9f1627e94e4/.github/workflows/autofix.yaml)
- **Run**: [#3166.1](https://github.com/kdeldycke/click-extra/actions/runs/31818354357)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.11.0`
