### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1051,11 +1051,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.11.0"
+version = "4.11.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/78/9b/560e4be8e26f6fd133a03630a8df0c663b9e8d61b4ade152b72005aec83b/platformdirs-4.11.0.tar.gz", hash = "sha256:0555d18370482847566ffabcaa53ad7c6c1c29f195989ae1ed634a05f76ea1e0", size = 31953, upload-time = "2026-07-21T13:09:36.565Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/0a/062135c9a98dac804265073cc3afdbec5ae1aa37980bb354f461bafe81b4/platformdirs-4.11.1.tar.gz", hash = "sha256:bb1af68078f25e2f3e111e2d43b8d536df41b73c8a684b40bb018223b66fae27", size = 32396, upload-time = "2026-08-07T23:06:48.516Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/68/d8d58938dfb1370b266a1a729e6d77a985be23689a0496498ee17b2cbf90/platformdirs-4.11.0-py3-none-any.whl", hash = "sha256:360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74", size = 23247, upload-time = "2026-07-21T13:09:35.422Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/85/9b31b44296cfa3bb56cddb35e6a0f6578bab0b490c0806c0245e32c6110c/platformdirs-4.11.1-py3-none-any.whl", hash = "sha256:2efd27d363e8dd2e661639ffb398865a5e0a46442a11d266bf375a0e0c10e386", size = 23261, upload-time = "2026-08-07T23:06:47.219Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-08-08`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [platformdirs](https://pypi.org/project/platformdirs/) | [`4.11.0` → `4.11.1`](https://github.com/tox-dev/platformdirs/compare/4.11.0...4.11.1) | 2026-08-07 (a week ago) |

### Release notes

<details>
<summary><code>platformdirs</code></summary>

#### [`4.11.1`](https://github.com/tox-dev/platformdirs/releases/tag/4.11.1)

<!-- Release notes generated using configuration in .github/release.yaml at 4.11.1 -->

##### What's Changed
* Let the non-ctypes resolvers find the desktop folder by @​darrenhuai in https://redirect.github.com/tox-dev/platformdirs/pull/519

##### New Contributors
* @​darrenhuai made their first contribution in https://redirect.github.com/tox-dev/platformdirs/pull/519

**Full Changelog**: https://redirect.github.com/tox-dev/platformdirs/compare/4.11.0...4.11.1

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [charset-normalizer](https://pypi.org/project/charset-normalizer/) | `3.4.9` | `3.5.0` | 2026-08-12 (3 days ago) | 2026-08-19 (in 4 days) |
| [platformdirs](https://pypi.org/project/platformdirs/) | `4.11.1` | `4.11.3` | 2026-08-13 (2 days ago) | 2026-08-20 (in 5 days) |
| [types-pyyaml](https://pypi.org/project/types-pyyaml/) | `6.0.12.20260724` | `6.0.12.20260815` | 2026-08-15 (just now) | 2026-08-22 (in a week) |
| [wcmatch](https://pypi.org/project/wcmatch/) | `11.0` | `11.0.1` | 2026-08-14 (a day ago) | 2026-08-21 (in 6 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://kdeldycke.github.io/repomatic/workflows.html#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`bd741a2e`](https://github.com/kdeldycke/click-extra/commit/bd741a2e1d590c195403ffb6ec80f1588c6e708d)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/click-extra/blob/bd741a2e1d590c195403ffb6ec80f1588c6e708d/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/bd741a2e1d590c195403ffb6ec80f1588c6e708d/.github/workflows/autofix.yaml)
- **Run**: [#3171.1](https://github.com/kdeldycke/click-extra/actions/runs/31867502847)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.11.0`
