### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.12.2"
+          version: "0.12.3"
       - name: Run repomatic metadata
         id: metadata
         # The `--exclude-newer-package` flag is not optional: the workflow-level
@@ -100,7 +100,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.12.2"
+          version: "0.12.3"
       - name: Install Python
         run: uv --no-progress venv --python 3.14
       - name: Install project
@@ -156,7 +156,7 @@ jobs:
     steps:
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.12.2"
+          version: "0.12.3"
       - name: Install Python
         run: uv --no-progress venv --python 3.14
 
@@ -228,7 +228,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.12.2"
+          version: "0.12.3"
       - name: Force native ARM64 Python on Windows ARM64
         # Workaround for https://github.com/astral-sh/uv/issues/12906: uv defaults to x86_64 Python on ARM64 Windows,
         # relying on transparent emulation, so an ARM64 Windows cell would silently test emulated x86_64 Python


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `7 days`: releases after `2026-08-08` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [uv](https://pypi.org/project/uv/) | `0.12.2` → `0.12.3` | 2026-08-07 (a week ago) |

### Release notes

<details>
<summary><code>uv</code></summary>

#### [`0.12.3`](https://github.com/astral-sh/uv/releases/tag/0.12.3)

##### Release Notes

Released on 2026-08-07.

###### Python

- Add CPython 3.13.15 ([#​20997](https://redirect.github.com/astral-sh/uv/pull/20997))

###### Preview features

- Add `--output-format` to select automatic, human-readable, or raw-byte output for `uv cache size` ([#​20992](https://redirect.github.com/astral-sh/uv/pull/20992))
- Preserve JSON output from `uv workspace metadata --quiet` while suppressing diagnostics ([#​20991](https://redirect.github.com/astral-sh/uv/pull/20991))
- Reduce memory usage for large workspaces by streaming `uv workspace metadata` JSON output ([#​20990](https://redirect.github.com/astral-sh/uv/pull/20990))

###### Performance

- Reduce Linux startup latency by initializing the workspace cache before spawning another thread ([#​20989](https://redirect.github.com/astral-sh/uv/pull/20989))
- Reuse compiled workspace exclusion patterns during workspace discovery ([#​20988](https://redirect.github.com/astral-sh/uv/pull/20988))
- Speed up conflict-heavy resolutions by avoiding materialized range complements ([#​20982](https://redirect.github.com/astral-sh/uv/pull/20982))
- Avoid slow procfs reads during Python interpreter discovery on Linux ([#​20987](https://redirect.github.com/astral-sh/uv/pull/20987))

###### Documentation

- Add PEP 740 attestations to the GitHub Actions publishing example ([#​20986](https://redirect.github.com/astral-sh/uv/pull/20986))
- Restrict the GitHub Actions publishing example to Python version tags ([#​20973](https://redirect.github.com/astral-sh/uv/pull/20973))
- Correct `--python-pin` to `--pin-python` in the `uv init --bare` example ([#​20876](https://redirect.github.com/astral-sh/uv/pull/20876))

##### Install uv 0.12.3

###### Install prebuilt binaries via shell script

```sh
curl --proto '=https' --tlsv1.2 -LsSf https://releases.astral.sh/github/uv/releases/download/0.12.3/uv-installer.sh | sh
```

###### Install prebuilt binaries via powershell script

```sh

... [Full release notes](https://github.com/astral-sh/uv/releases/tag/0.12.3)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [uv](https://pypi.org/project/uv/) | `0.12.3` | `0.12.4` | 2026-08-13 (2 days ago) | 2026-08-20 (in 5 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`bd741a2e`](https://github.com/kdeldycke/click-extra/commit/bd741a2e1d590c195403ffb6ec80f1588c6e708d)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/click-extra/blob/bd741a2e1d590c195403ffb6ec80f1588c6e708d/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/bd741a2e1d590c195403ffb6ec80f1588c6e708d/.github/workflows/autofix.yaml)
- **Run**: [#3171.1](https://github.com/kdeldycke/click-extra/actions/runs/31867502847)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.11.0`
