### PR TITLE
Format Python

### DIFF
--- a/tests/test_screenshots.py
+++ b/tests/test_screenshots.py
@@ -436,7 +436,16 @@ def test_screenshot_wrap_matches_the_composition(invoke, tmp_path):
     assert (
         invoke(
             screenshot_cmd,
-            ["--wrap", "--fragment", "--head", "3", "--output", str(shortcut), "--", *target],
+            [
+                "--wrap",
+                "--fragment",
+                "--head",
+                "3",
+                "--output",
+                str(shortcut),
+                "--",
+                *target,
+            ],
         ).exit_code
         == 0
     )
@@ -445,11 +454,17 @@ def test_screenshot_wrap_matches_the_composition(invoke, tmp_path):
             screenshot_cmd,
             [
                 "--fragment",
-                "--head", "3",
-                "--prompt", f"click-extra wrap -- {' '.join(target)}",
-                "--output", str(composed),
+                "--head",
+                "3",
+                "--prompt",
+                f"click-extra wrap -- {' '.join(target)}",
+                "--output",
+                str(composed),
                 "--",
-                shutil.which("click-extra"), "wrap", "--", *target,
+                shutil.which("click-extra"),
+                "wrap",
+                "--",
+                *target,
             ],
         ).exit_code
         == 0
@@ -458,4 +473,7 @@ def test_screenshot_wrap_matches_the_composition(invoke, tmp_path):
     text = html_to_text(shortcut.read_text(encoding="utf-8"))
     assert text == html_to_text(composed.read_text(encoding="utf-8"))
     # The prompt shows what a reader types, not the plumbing that ran.
-    assert text.splitlines()[0] == "$ click-extra wrap -- click_extra.cli:demo_themes --help"
+    assert (
+        text.splitlines()[0]
+        == "$ click-extra wrap -- click_extra.cli:demo_themes --help"
+    )


### PR DESCRIPTION
> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`format-python`](https://kdeldycke.github.io/repomatic/workflows.html#format-python-format-python)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`7a8bd3bc`](https://github.com/kdeldycke/click-extra/commit/7a8bd3bce86aede55c96849cf7b662629cf1644f)
- **Job**: [`format-python`](https://github.com/kdeldycke/click-extra/blob/7a8bd3bce86aede55c96849cf7b662629cf1644f/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/7a8bd3bce86aede55c96849cf7b662629cf1644f/.github/workflows/autofix.yaml)
- **Run**: [#3186.1](https://github.com/kdeldycke/click-extra/actions/runs/31904381522)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.11.0`
