### PR TITLE
Format Markdown

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1130,20 +1130,20 @@ assert "Syncing" not in result.stdout
 
 Several dialects are supported:
 
-| Format                              | Extensions        | Description                                                                               | Enabled by default |
-| :---------------------------------- | :---------------- | :---------------------------------------------------------------------------------------- | :----------------- |
-| [`TOML`](#toml)                     | `*.toml`          | -                                                                                         | ✅                 |
-| [`YAML`](#yaml)                     | `*.yaml`, `*.yml` | -                                                                                         | ❌                 |
-| [`JSON`](#json)                     | `*.json`          | -                                                                                         | ✅                 |
-| [`JSON5`](#json5)                   | `*.json5`         | A [superset of JSON made for configuration file](https://json5.org)                       | ❌                 |
-| [`JSONC`](#jsonc)                   | `*.jsonc`         | Like JSON, but with comments and trailing commas                                          | ❌                 |
-| [`HJSON`](#hjson)                   | `*.hjson`         | Another flavor of a [user-friendly JSON](https://hjson.github.io)                         | ❌                 |
-| [`INI`](#ini)                       | `*.ini`           | With extended interpolation, multi-level sections and non-native types (`list`, `set`, …) | ✅                 |
-| [`XML`](#xml)                       | `*.xml`           | -                                                                                         | ❌                 |
-| [`plist`](#plist)                   | `*.plist`         | Apple's property list, in its XML or binary variant                                       | ✅                 |
-| [`SQLITE`](#sqlite)                 | `*.sqlite`, `*.sqlite3` | Reads a `config` table of dotted keys and JSON-encoded values                       | ✅                 |
-| [`ARGFILE`](#argfile)               | `*.conf`          | Plain-text list of command-line options, in the style of `mpv` and `yt-dlp`            | ✅                 |
-| [`PYPROJECT_TOML`](#pyproject-toml) | `pyproject.toml`  | Reads `[tool.*]`{l=toml}{l=toml} sections from `pyproject.toml`                           | ✅                 |
+| Format                              | Extensions              | Description                                                                               | Enabled by default |
+| :---------------------------------- | :---------------------- | :---------------------------------------------------------------------------------------- | :----------------- |
+| [`TOML`](#toml)                     | `*.toml`                | -                                                                                         | ✅                 |
+| [`YAML`](#yaml)                     | `*.yaml`, `*.yml`       | -                                                                                         | ❌                 |
+| [`JSON`](#json)                     | `*.json`                | -                                                                                         | ✅                 |
+| [`JSON5`](#json5)                   | `*.json5`               | A [superset of JSON made for configuration file](https://json5.org)                       | ❌                 |
+| [`JSONC`](#jsonc)                   | `*.jsonc`               | Like JSON, but with comments and trailing commas                                          | ❌                 |
+| [`HJSON`](#hjson)                   | `*.hjson`               | Another flavor of a [user-friendly JSON](https://hjson.github.io)                         | ❌                 |
+| [`INI`](#ini)                       | `*.ini`                 | With extended interpolation, multi-level sections and non-native types (`list`, `set`, …) | ✅                 |
+| [`XML`](#xml)                       | `*.xml`                 | -                                                                                         | ❌                 |
+| [`plist`](#plist)                   | `*.plist`               | Apple's property list, in its XML or binary variant                                       | ✅                 |
+| [`SQLITE`](#sqlite)                 | `*.sqlite`, `*.sqlite3` | Reads a `config` table of dotted keys and JSON-encoded values                             | ✅                 |
+| [`ARGFILE`](#argfile)               | `*.conf`                | Plain-text list of command-line options, in the style of `mpv` and `yt-dlp`               | ✅                 |
+| [`PYPROJECT_TOML`](#pyproject-toml) | `pyproject.toml`        | Reads `[tool.*]`{l=toml}{l=toml} sections from `pyproject.toml`                           | ✅                 |
 
 Formats depending on third-party packages are not enabled by default. You need to [install Click Extra with the corresponding extra dependency group](install.md#extra-dependencies) to enable them.
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -31,23 +31,23 @@ You may also reach the same entry through the literal string (`ctx.meta["click_e
 
 The table below lists every entry Click Extra writes, the option that triggers it, and the value's shape. Entries marked *write-only* are not read back internally: they exist so your code can inspect what the user picked.
 
-| Constant                  | String key                    | Set by                                                       | Value                                                                 |
-| ------------------------- | ----------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------- |
-| `context.RAW_ARGS`        | `click_extra.raw_args`        | `Command.make_context` (always, on `@command` group)         | `list[str]`: pre-parsed `argv` slice fed to the current command       |
-| `context.CONF_SOURCE`     | `click_extra.conf_source`     | `ConfigOption.load_conf` (`@config_option`)                  | `pathlib.Path \| URL \| None`: file the configuration was loaded from |
-| `context.CONF_FULL`       | `click_extra.conf_full`       | `ConfigOption.load_conf` (`@config_option`)                  | `dict \| None`: full parsed configuration document                    |
+| Constant                  | String key                    | Set by                                                       | Value                                                                   |
+| ------------------------- | ----------------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------- |
+| `context.RAW_ARGS`        | `click_extra.raw_args`        | `Command.make_context` (always, on `@command` group)         | `list[str]`: pre-parsed `argv` slice fed to the current command         |
+| `context.CONF_SOURCE`     | `click_extra.conf_source`     | `ConfigOption.load_conf` (`@config_option`)                  | `pathlib.Path \| URL \| None`: file the configuration was loaded from   |
+| `context.CONF_FULL`       | `click_extra.conf_full`       | `ConfigOption.load_conf` (`@config_option`)                  | `dict \| None`: full parsed configuration document                      |
 | `context.CONF_SOURCES`    | `click_extra.conf_sources`    | `ConfigOption.load_conf` (`@config_option`)                  | `tuple[(path, dict), ...]`: every loaded file, highest precedence first |
-| `context.TOOL_CONFIG`     | `click_extra.tool_config`     | `ConfigOption._apply_config_schema` (with `config_schema`)   | The deserialised app section (also reachable via `get_tool_config()`) |
-| `context.VERBOSITY_LEVEL` | `click_extra.verbosity_level` | `--verbosity` / `--verbose` callbacks (reconciled)           | `LogLevel`: the highest level any verbosity option picked             |
-| `context.VERBOSITY`       | `click_extra.verbosity`       | `--verbosity` callback                                       | `LogLevel`: raw value of `--verbosity LEVEL` *(write-only)*           |
-| `context.VERBOSE`         | `click_extra.verbose`         | `--verbose` / `-v` callback                                  | `int`: repetition count *(write-only)*                                |
-| `context.START_TIME`      | `click_extra.start_time`      | `--time` callback (`@timer_option`)                          | `float`: `time.perf_counter()` snapshot                               |
-| `context.JOBS`            | `click_extra.jobs`            | `--jobs` callback (`@jobs_option`)                           | `int`: effective parallel job count (clamped to >= 1)                 |
-| `context.PROGRESS`        | `click_extra.progress`        | `ProgressOption.set_progress` (always present on `@command`) | `bool`: `True` when progress spinners may display                     |
-| `context.TABLE_FORMAT`    | `click_extra.table_format`    | `--table-format` callback (`@table_format_option`)           | `TableFormat`                                                         |
-| `context.SORT_BY`         | `click_extra.sort_by`         | `--sort-by` callback (`@sort_by_option`)                     | `tuple[str, ...]`: column IDs in priority order                       |
-| `context.THEME`           | `click_extra.theme.active`    | `--theme` callback (always present on `@command`)            | `HelpTheme`: palette picked for this invocation                       |
-| `context.ZERO_EXIT`       | `click_extra.zero_exit`       | `-0` / `--zero-exit` callback (`@zero_exit_option`)          | `bool`: `True` to always exit 0 *(write-only)*                        |
+| `context.TOOL_CONFIG`     | `click_extra.tool_config`     | `ConfigOption._apply_config_schema` (with `config_schema`)   | The deserialised app section (also reachable via `get_tool_config()`)   |
+| `context.VERBOSITY_LEVEL` | `click_extra.verbosity_level` | `--verbosity` / `--verbose` callbacks (reconciled)           | `LogLevel`: the highest level any verbosity option picked               |
+| `context.VERBOSITY`       | `click_extra.verbosity`       | `--verbosity` callback                                       | `LogLevel`: raw value of `--verbosity LEVEL` *(write-only)*             |
+| `context.VERBOSE`         | `click_extra.verbose`         | `--verbose` / `-v` callback                                  | `int`: repetition count *(write-only)*                                  |
+| `context.START_TIME`      | `click_extra.start_time`      | `--time` callback (`@timer_option`)                          | `float`: `time.perf_counter()` snapshot                                 |
+| `context.JOBS`            | `click_extra.jobs`            | `--jobs` callback (`@jobs_option`)                           | `int`: effective parallel job count (clamped to >= 1)                   |
+| `context.PROGRESS`        | `click_extra.progress`        | `ProgressOption.set_progress` (always present on `@command`) | `bool`: `True` when progress spinners may display                       |
+| `context.TABLE_FORMAT`    | `click_extra.table_format`    | `--table-format` callback (`@table_format_option`)           | `TableFormat`                                                           |
+| `context.SORT_BY`         | `click_extra.sort_by`         | `--sort-by` callback (`@sort_by_option`)                     | `tuple[str, ...]`: column IDs in priority order                         |
+| `context.THEME`           | `click_extra.theme.active`    | `--theme` callback (always present on `@command`)            | `HelpTheme`: palette picked for this invocation                         |
+| `context.ZERO_EXIT`       | `click_extra.zero_exit`       | `-0` / `--zero-exit` callback (`@zero_exit_option`)          | `bool`: `True` to always exit 0 *(write-only)*                          |
 
 ## Worked examples
 

--- a/docs/machine-readable.md
+++ b/docs/machine-readable.md
@@ -68,14 +68,14 @@ assert "- `CITY`: Name of the city to report on." in result.output
 
 ### The format list
 
-| Format          | What it renders                                                                             |
-| --------------- | ------------------------------------------------------------------------------------------- |
-| `carapace`      | A [Carapace completion spec](carapace.md) (YAML), which doubles as a command-and-flag tree. |
-| `json`          | This command as a JSON object, its direct subcommands listed by name.                       |
-| `json-full`     | Every command of the tree, under a `commands` array.                                        |
-| `man`           | This command as a man page: the roff source [`--man`](man-page.md#reading-a-manual) typesets to read.  |
-| `markdown`      | This command as a Markdown document, one section per topic.                                 |
-| `markdown-full` | Every command of the tree as one Markdown document.                                         |
+| Format          | What it renders                                                                                       |
+| --------------- | ----------------------------------------------------------------------------------------------------- |
+| `carapace`      | A [Carapace completion spec](carapace.md) (YAML), which doubles as a command-and-flag tree.           |
+| `json`          | This command as a JSON object, its direct subcommands listed by name.                                 |
+| `json-full`     | Every command of the tree, under a `commands` array.                                                  |
+| `man`           | This command as a man page: the roff source [`--man`](man-page.md#reading-a-manual) typesets to read. |
+| `markdown`      | This command as a Markdown document, one section per topic.                                           |
+| `markdown-full` | Every command of the tree as one Markdown document.                                                   |
 
 ```{note}
 The plain and `-full` variants differ in how much they hand over at once. A plain render describes one command and *names* its children, so a reader descends one level at a time rather than pulling a whole tree into a context window to answer a question about one leaf. The `-full` variants are for the opposite job: generating documentation, or diffing a CLI's whole surface between two releases.


### PR DESCRIPTION
> [!TIP]
> Customize Markdown formatting via [`[tool.mdformat]`](https://mdformat.readthedocs.io/en/stable/users/configuration_file.html) in your `pyproject.toml`, or via a native `.mdformat.toml` file.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`format-markdown`](https://repomatic.net/workflows#format-markdown-format-markdown)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`bc4a98c5`](https://github.com/kdeldycke/click-extra/commit/bc4a98c5642e47f6941c12bc73d4bf67ef9bcfee)
- **Job**: [`format-markdown`](https://github.com/kdeldycke/click-extra/blob/bc4a98c5642e47f6941c12bc73d4bf67ef9bcfee/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/bc4a98c5642e47f6941c12bc73d4bf67ef9bcfee/.github/workflows/autofix.yaml)
- **Run**: [#3243.1](https://github.com/kdeldycke/click-extra/actions/runs/32370423175)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.13.0`
