### PR TITLE
Format Python

### DIFF
--- a/click_extra/config/option.py
+++ b/click_extra/config/option.py
@@ -1049,9 +1049,7 @@ class ConfigOption(ExtraOption, ParamStructure):
                     yield candidate, conf
                     break
             else:
-                logger.debug(
-                    f"{candidate} has no [tool.{cli_name}] section; skipping."
-                )
+                logger.debug(f"{candidate} has no [tool.{cli_name}] section; skipping.")
 
     def _search_pyproject_cwd(
         self,
@@ -1133,10 +1131,10 @@ class ConfigOption(ExtraOption, ParamStructure):
             logger.debug(f"{location} does not match {self.file_pattern}.")
             return None
 
-        logger.debug(
-            f"Parsing {location} with {','.join(map(str, matching_formats))}"
-        )
-        for conf in self.parse_conf(content, formats=matching_formats, location=location):
+        logger.debug(f"Parsing {location} with {','.join(map(str, matching_formats))}")
+        for conf in self.parse_conf(
+            content, formats=matching_formats, location=location
+        ):
             if conf:
                 return conf
             logger.debug("Empty configuration, try next format.")
@@ -1331,8 +1329,7 @@ class ConfigOption(ExtraOption, ParamStructure):
                     return raw_value
             except (ValueError, json.JSONDecodeError) as ex:
                 raise ValueError(
-                    f"Cannot convert {decl} value {raw_value!r} to "
-                    f"{target_type} type."
+                    f"Cannot convert {decl} value {raw_value!r} to {target_type} type."
                 ) from ex
             raise ValueError(
                 f"Cannot handle the conversion of {decl} value {raw_value!r} "
@@ -1615,8 +1612,7 @@ class ConfigOption(ExtraOption, ParamStructure):
             )
             if not report.ok:
                 logger.critical(
-                    f"Configuration validation error in {location}: "
-                    f"{report.errors[0]}"
+                    f"Configuration validation error in {location}: {report.errors[0]}"
                 )
                 ctx.exit(1)
             assert report.merged_conf is not None  # params_template is always set.
@@ -1801,8 +1797,7 @@ class ConfigOption(ExtraOption, ParamStructure):
             if not layers:
                 formats = list(map(str, self.file_format_patterns))
                 message = (
-                    f"Error parsing file as "
-                    f"{', '.join(formats[:-1])} or {formats[-1]}."
+                    f"Error parsing file as {', '.join(formats[:-1])} or {formats[-1]}."
                 )
                 if explicit_conf:
                     logger.critical(message)


### PR DESCRIPTION
> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`format-python`](https://repomatic.net/workflows#format-python-format-python)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`0a8a6c6d`](https://github.com/kdeldycke/click-extra/commit/0a8a6c6d5135b30311d67a3d9097b674f93911fb)
- **Job**: [`format-python`](https://github.com/kdeldycke/click-extra/blob/0a8a6c6d5135b30311d67a3d9097b674f93911fb/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/0a8a6c6d5135b30311d67a3d9097b674f93911fb/.github/workflows/autofix.yaml)
- **Run**: [#3241.1](https://github.com/kdeldycke/click-extra/actions/runs/32346969990)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.13.0`
