### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.12.3"
+          version: "0.12.5"
       - name: Run repomatic metadata
         id: metadata
         # The `--exclude-newer-package` flag is not optional: the workflow-level
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.12.3"
+          version: "0.12.5"
       - name: Install Python
         run: uv --no-progress venv --python 3.14
       - name: Install project
@@ -162,7 +162,7 @@ jobs:
     steps:
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.12.3"
+          version: "0.12.5"
       - name: Install Python
         run: uv --no-progress venv --python 3.14
 
@@ -238,7 +238,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.12.3"
+          version: "0.12.5"
       - name: Force native ARM64 Python on Windows ARM64
         # Workaround for https://github.com/astral-sh/uv/issues/12906: uv defaults to x86_64 Python on ARM64 Windows,
         # relying on transparent emulation, so an ARM64 Windows cell would silently test emulated x86_64 Python


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age) cooldown `7 days`: releases after `2026-08-18` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [uv](https://pypi.org/project/uv/) | `0.12.3` → `0.12.5` | 2026-08-14 (a week ago) |

### Release notes

<details>
<summary><code>uv</code></summary>

#### [`0.12.4`](https://github.com/astral-sh/uv/releases/tag/0.12.4)

##### Release Notes

Released on 2026-08-13.

###### Enhancements

- Prefer post-quantum key exchange and enable opt-in TLS diagnostics ([#​21054](https://redirect.github.com/astral-sh/uv/pull/21054))
- Accept whitespace before versions in noncompliant wildcard comparisons such as `Requires-Python: >= 3.5.*` ([#​21012](https://redirect.github.com/astral-sh/uv/pull/21012))
- Report a specific error when a PEP 723 closing tag contains trailing whitespace or other content ([#​20944](https://redirect.github.com/astral-sh/uv/pull/20944))
- Omit source-span carets from diagnostics for empty PEP 508 requirements ([#​21094](https://redirect.github.com/astral-sh/uv/pull/21094))

###### Preview features

- Add `uv check --no-install-project` and respect `UV_NO_INSTALL_PROJECT` to install dependencies without building or installing the project ([#​21085](https://redirect.github.com/astral-sh/uv/pull/21085))
- Make the ty subprocess invoked by `uv check` honor uv's color and progress settings, including quiet mode ([#​21086](https://redirect.github.com/astral-sh/uv/pull/21086))

###### Performance

- Speed up resolutions with long runs of unavailable package versions by coalescing gaps in the resolver's version ranges ([#​20804](https://redirect.github.com/astral-sh/uv/pull/20804))
- Speed up Simple API parsing by deserializing PyPI and Pyx file metadata directly ([#​21041](https://redirect.github.com/astral-sh/uv/pull/21041))

###### Bug fixes

- Use windowed `pythonw.exe` launchers for virtual environments created from managed Python minor-version links ([#​19235](https://redirect.github.com/astral-sh/uv/pull/19235))
- Allow `uv lock` to proceed when `.venv` is an unusable project environment ([#​21068](https://redirect.github.com/astral-sh/uv/pull/21068))
- Respect `fork-strategy` when ordering forks created from `environments` or existing lockfile `resolution-markers` ([#​21000](https://redirect.github.com/astral-sh/uv/pull/21000))

... [Full release notes](https://github.com/astral-sh/uv/releases/tag/0.12.4)

#### [`0.12.5`](https://github.com/astral-sh/uv/releases/tag/0.12.5)

##### Release Notes

Released on 2026-08-14.

###### Python

- Add CPython 3.10.21, 3.11.16, and 3.12.14 ([#​21138](https://redirect.github.com/astral-sh/uv/pull/21138))
- Prefer newer versions and standard variants when selecting between equally prioritized Python interpreters ([#​21134](https://redirect.github.com/astral-sh/uv/pull/21134))

###### Enhancements

- Simplify errors and hints for invalid editable requirements, and redact credentials in requirement URLs ([#​21130](https://redirect.github.com/astral-sh/uv/pull/21130))

###### Preview features

- Allow `--index` and `--default-index` to select configured package indexes by name with the `index-by-name` preview feature ([#​17455](https://redirect.github.com/astral-sh/uv/pull/17455))
- Include distribution artifact URLs and hashes in CycloneDX SBOM exports by default ([#​21131](https://redirect.github.com/astral-sh/uv/pull/21131))
- Fall back to logical file sizes when using `cache-physical-space` on filesystems that do not support physical-space accounting ([#​21133](https://redirect.github.com/astral-sh/uv/pull/21133))

###### Bug fixes

- Resolve relative package index paths in PEP 723 scripts against the script directory ([#​21097](https://redirect.github.com/astral-sh/uv/pull/21097))

##### Install uv 0.12.5

###### Install prebuilt binaries via shell script

```sh
curl --proto '=https' --tlsv1.2 -LsSf https://releases.astral.sh/github/uv/releases/download/0.12.5/uv-installer.sh | sh
```

###### Install prebuilt binaries via powershell script

```sh
powershell -ExecutionPolicy Bypass -c "irm https://releases.astral.sh/github/uv/releases/download/0.12.5/uv-installer.ps1 | iex"
```

##### Download uv 0.12.5

|  File  | Platform | Checksum |
|--------|----------|----------|

... [Full release notes](https://github.com/astral-sh/uv/releases/tag/0.12.5)

</details>

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://repomatic.net/configuration) options:

- [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age)
- [`workflow-pins.sync`](https://repomatic.net/configuration#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://repomatic.net/workflows#sync-workflow-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`7f6308e5`](https://github.com/kdeldycke/click-extra/commit/7f6308e5cd07728703a1a9640dd2d60189bfe9f8)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/click-extra/blob/7f6308e5cd07728703a1a9640dd2d60189bfe9f8/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/7f6308e5cd07728703a1a9640dd2d60189bfe9f8/.github/workflows/autofix.yaml)
- **Run**: [#3257.1](https://github.com/kdeldycke/click-extra/actions/runs/32815232625)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.13.0`
