### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1997,11 +1997,11 @@ wheels = [
 
 [[package]]
 name = "types-pygments"
-version = "2.20.0.20260728"
+version = "2.21.0.20260819"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/17/99/0cee9f28ce2c1b8ce6619a6fc4e92bed751d2afc82f27c4e2682b080e3e3/types_pygments-2.20.0.20260728.tar.gz", hash = "sha256:dd0a49d84fd9e3f08ab3a3191779e4732a91bb1fad2e80178cf4574e8f35684d", size = 21362, upload-time = "2026-07-28T04:51:27.768Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/2b/b3e929c39fb056f0e44560acbe53a7c3f28f428af5362d043642d80b31ec/types_pygments-2.21.0.20260819.tar.gz", hash = "sha256:68e0cb27115b08b681c843e30a153b5d9850c048e1158623ada36ccd4cf7e89b", size = 21509, upload-time = "2026-08-19T02:47:15.827Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/29/394fd32bc24c95fd957f8ec0916b54846eb6e1d416c333272aa32b4e25df/types_pygments-2.20.0.20260728-py3-none-any.whl", hash = "sha256:22974ff0b06fcf752e5d91039a2a6bfd93607f13862b6dc1320a576506144df6", size = 29060, upload-time = "2026-07-28T04:51:26.835Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a5/10a2de06b53a36f4334391fcf292b51877cbc71d3f6eac353e7b87a0a17e/types_pygments-2.21.0.20260819-py3-none-any.whl", hash = "sha256:85e216770d616db6a7e96fb70c2de9d9f283b746c37edb7768ce645bdbcaddb2", size = 29099, upload-time = "2026-08-19T02:47:14.81Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-08-21`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [types-pygments](https://pypi.org/project/types-pygments/) | `2.20.0.20260728` → `2.21.0.20260819` | 2026-08-19 (a week ago) |

### Release notes

<details>
<summary><code>types-pygments</code></summary>

[Changelog](https://redirect.github.com/typeshed-internal/stub_uploader/blob/main/data/changelogs/Pygments.md)

</details>

## ❄️ Cooldown bypasses

Packages pulled in ahead of the cooldown by an [`exclude-newer-package`](https://docs.astral.sh/uv/reference/settings/#exclude-newer-package) freeze. Each entry is cleared from `pyproject.toml` automatically once its held version ages past the `exclude-newer` cutoff.

| Package | Held at | Held until |
| :-- | :-- | :-- |
| [click](https://pypi.org/project/click/) | `8.5.0` | 2026-09-02 (in 5 days) |

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [imagesize](https://pypi.org/project/imagesize/) | `2.0.0` | `2.0.1` | 2026-08-24 (4 days ago) | 2026-08-31 (in 3 days) |
| [json-with-comments](https://pypi.org/project/json-with-comments/) | `1.2.10` | `1.3.0` | 2026-08-24 (4 days ago) | 2026-08-31 (in 3 days) |
| [platformdirs](https://pypi.org/project/platformdirs/) | `4.11.3` | `4.11.5` | 2026-08-27 (a day ago) | 2026-09-03 (in 6 days) |
| [pymdown-extensions](https://pypi.org/project/pymdown-extensions/) | `11.0.1` | `11.0.2` | 2026-08-22 (6 days ago) | 2026-08-29 (in a day) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | `3.13.2` | `3.13.4` | 2026-08-24 (4 days ago) | 2026-08-31 (in 3 days) |
| [types-docutils](https://pypi.org/project/types-docutils/) | `0.22.3.20260724` | `0.23.0.20260827` | 2026-08-27 (a day ago) | 2026-09-03 (in 6 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://repomatic.net/configuration) options:

- [`uv-lock.sync`](https://repomatic.net/configuration#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://repomatic.net/workflows#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`f6becc50`](https://github.com/kdeldycke/click-extra/commit/f6becc506c63b3318a74113d78c1103ad0744b5f)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/click-extra/blob/f6becc506c63b3318a74113d78c1103ad0744b5f/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/f6becc506c63b3318a74113d78c1103ad0744b5f/.github/workflows/autofix.yaml)
- **Run**: [#3274.1](https://github.com/kdeldycke/click-extra/actions/runs/33152283293)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.14.0`
