### PR TITLE
Format Python

### DIFF
--- a/tests/test_screenshots.py
+++ b/tests/test_screenshots.py
@@ -384,9 +384,7 @@ def test_animation_windows_tile_the_cycle(name):
     ):
         steps = [
             (float(at), state)
-            for at, state in re.findall(
-                r"([\d.]+)% \{ visibility: (\w+);", keyframes
-            )
+            for at, state in re.findall(r"([\d.]+)% \{ visibility: (\w+);", keyframes)
         ]
         opens = next(at for at, state in steps if state == "visible")
         closes = next(at for at, state in steps if state == "hidden" and at > opens)
@@ -460,8 +458,11 @@ def test_emphasized_lines_are_banded_where_they_sit():
     assert offsets[1] - offsets[0] == pytest.approx(2 * LINE_HEIGHT)
 
     svg = render_svg(text, columns=20, emphasize=(1,), margin=40, padding=12)
-    window = re.search(r'<rect fill="#[0-9a-f]+" stroke="[^"]*"[^>]*x="([\d.]+)"'
-                       r'[^>]*width="([\d.]+)"', svg)
+    window = re.search(
+        r'<rect fill="#[0-9a-f]+" stroke="[^"]*"[^>]*x="([\d.]+)"'
+        r'[^>]*width="([\d.]+)"',
+        svg,
+    )
     band = re.search(r'-window\)">.*?<rect[^>]*x="([\d.]+)"[^>]*width="([\d.]+)"', svg)
     assert window and band
     assert band.groups() == window.groups(), "a band is as wide as the window"
@@ -502,9 +503,7 @@ FRAME_BAND_RE = re.compile(
 def banded_frames(svg: str) -> set[int]:
     """Which frames of an animated capture draw a band."""
     return {
-        int(index)
-        for _, index, drawn in FRAME_BAND_RE.findall(svg)
-        if "<rect" in drawn
+        int(index) for _, index, drawn in FRAME_BAND_RE.findall(svg) if "<rect" in drawn
     }
 
 


### PR DESCRIPTION
> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`format-python`](https://repomatic.net/workflows#format-python-format-python)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`d874bc52`](https://github.com/kdeldycke/click-extra/commit/d874bc52ed9120a9e9120870a9bda8286498428c)
- **Job**: [`format-python`](https://github.com/kdeldycke/click-extra/blob/d874bc52ed9120a9e9120870a9bda8286498428c/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/d874bc52ed9120a9e9120870a9bda8286498428c/.github/workflows/autofix.yaml)
- **Run**: [#3273.1](https://github.com/kdeldycke/click-extra/actions/runs/33148778723)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.14.0`
