### PR TITLE
Format Markdown

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,11 +6,15 @@
 > This version is **not released yet** and is under active development.
 
 - Animated captures now take `hold="auto"` (and `:screenshot-hold: auto`), pausing the loop on the final screen for as long as its line count asks; a `:screenshot-record:` block defaults to it.
+
 - Fix `record_command` mangling a multi-byte glyph split across two pty reads into a replacement character.
+
 - Fix a capture inheriting `TERM_PROGRAM` from the terminal it is taken from, which drew an emoji-bearing table wider on one machine than another.
+
 - Fix recorded screens dropping every line the command ended with `\r\n`, the form a pseudo-terminal substitutes for each newline.
 
 - Stop `{env_info}` resolving the host's name, which stalled every `--verbosity DEBUG` run for as long as the machine's reverse DNS took to answer.
+
 - Regroup the Sphinx, MkDocs, Pygments, screenshot, snippet and man-page documentation under a documentation-tooling section of the sidebar.
 
 ## [`9.0.0` (2026-08-29)](https://github.com/kdeldycke/click-extra/compare/v8.9.1...v9.0.0)


### PR DESCRIPTION
> [!TIP]
> Customize Markdown formatting via [`[tool.mdformat]`](https://mdformat.readthedocs.io/en/stable/users/configuration_file.html) in your `pyproject.toml`, or via a native `.mdformat.toml` file.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`format-markdown`](https://repomatic.net/workflows#format-markdown-format-markdown)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`49981c08`](https://github.com/kdeldycke/click-extra/commit/49981c0894c3732b3acdf457b6516327c72e6a4b)
- **Job**: [`format-markdown`](https://github.com/kdeldycke/click-extra/blob/49981c0894c3732b3acdf457b6516327c72e6a4b/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/49981c0894c3732b3acdf457b6516327c72e6a4b/.github/workflows/autofix.yaml)
- **Run**: [#3305.1](https://github.com/kdeldycke/click-extra/actions/runs/33254148416)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.14.0`
