### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -812,11 +812,11 @@ wheels = [
 
 [[package]]
 name = "json-with-comments"
-version = "1.2.10"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bf/6d/638e8adbb2b92bb0803c092dd8ae6482945961c8545fc7e2f21c48233928/json_with_comments-1.2.10.tar.gz", hash = "sha256:0020b321cf6c80963c85f95ce985e71332f1797ed49abfd1cd675b3bdee24a28", size = 6788, upload-time = "2024-12-10T05:46:37.415Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/8d/08b696af5b68210999c8f9f4ba1729ccbd4ae2bbf535f547a9d07ca36ce7/json_with_comments-1.3.0.tar.gz", hash = "sha256:8e9668f9aaa9f50cb546828da958c606e45f3866daceb51f16b0ee61985c0677", size = 7070, upload-time = "2026-08-24T01:33:14.494Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/8a/f67dadb0648f00ac2249d3ef32532f0d5a2e72016f8426290ce6fe575870/json_with_comments-1.2.10-py3-none-any.whl", hash = "sha256:d7989c2577b1f8cbba735209f8d388d21017feb42ef30c29c230040f86b42700", size = 6533, upload-time = "2024-12-10T05:46:34.856Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/72/79259c11af4c22f187d0da18411982883428c2e915b2f9eb43bcd20d81fe/json_with_comments-1.3.0-py3-none-any.whl", hash = "sha256:cc96215e8960687180a6e60db8567c806ba40fb56187b2b8cf60ccc0bdfeb81e", size = 6603, upload-time = "2026-08-24T01:33:13.275Z" },
 ]
 
 [[package]]
@@ -1154,15 +1154,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "11.0.1"
+version = "11.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/17/2db4b414de89659144488e0d9c6c0bf0c8395841dc12d81d0532cc6ef310/pymdown_extensions-11.0.2.tar.gz", hash = "sha256:9506fcbe66fa355a775b768084334238dd6805020ac4b92bea0c0dda6f8f223d", size = 855419, upload-time = "2026-08-22T19:28:47.236Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/43/9f45ec4d14e596efc32c925a78104934790438b0c0628b70d741016734ad/pymdown_extensions-11.0.2-py3-none-any.whl", hash = "sha256:259910762019732caa1dfd76f3faa62c59f191d46573e80bcb1d13c0f675bbe5", size = 269929, upload-time = "2026-08-22T19:28:45.389Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-08-24`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [json-with-comments](https://pypi.org/project/json-with-comments/) | [`1.2.10` → `1.3.0`](https://github.com/n-takumasa/json-with-comments/compare/v1.2.10...v1.3.0) | 2026-08-24 (a week ago) |
| [pymdown-extensions](https://pypi.org/project/pymdown-extensions/) | [`11.0.1` → `11.0.2`](https://github.com/facelessuser/pymdown-extensions/compare/11.0.1...11.0.2) | 2026-08-22 (a week ago) |

### Release notes

<details>
<summary><code>json-with-comments</code></summary>

#### [`v1.3.0`](https://github.com/n-takumasa/json-with-comments/releases/tag/v1.3.0)

##### What's Changed
* Raise JSONDecodeError instead of IndexError on empty input by @​SAY-5 in https://redirect.github.com/n-takumasa/json-with-comments/pull/51
* feat: add `array_hook` parameter (py3.15) by @​n-takumasa in https://redirect.github.com/n-takumasa/json-with-comments/pull/42

**Full Changelog**: https://redirect.github.com/n-takumasa/json-with-comments/compare/v1.2.10...v1.3.0

</details>

<details>
<summary><code>pymdown-extensions</code></summary>

#### [`11.0.2`](https://github.com/facelessuser/pymdown-extensions/releases/tag/11.0.2)

##### 11.0.2

-   **FIX**: InlineHilite: Improve performance of inline code matching.
-   **FIX**: Keys: Fix regex pattern inefficiencies.
-   **FIX**: Blocks.HTML: Fix backtracking in HTML extension.

</details>

## ❄️ Cooldown bypasses

Packages pulled in ahead of the cooldown by an [`exclude-newer-package`](https://docs.astral.sh/uv/reference/settings/#exclude-newer-package) freeze. Each entry is cleared from `pyproject.toml` automatically once its held version ages past the `exclude-newer` cutoff.

| Package | Held at | Held until |
| :-- | :-- | :-- |
| [click](https://pypi.org/project/click/) | `8.5.0` | 2026-09-02 (in 2 days) |

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [coverage](https://pypi.org/project/coverage/) | `7.15.4` | `7.16.0` | 2026-08-28 (3 days ago) | 2026-09-04 (in 4 days) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.6.0` | `13.7.0` | 2026-08-28 (3 days ago) | 2026-09-04 (in 4 days) |
| [imagesize](https://pypi.org/project/imagesize/) | `2.0.0` | `2.0.1` | 2026-08-24 (a week ago) | 2026-08-31 (just now) |
| [platformdirs](https://pypi.org/project/platformdirs/) | `4.11.3` | `4.11.5` | 2026-08-27 (4 days ago) | 2026-09-03 (in 3 days) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | `3.13.2` | `3.13.4` | 2026-08-24 (a week ago) | 2026-08-31 (just now) |
| [types-docutils](https://pypi.org/project/types-docutils/) | `0.22.3.20260724` | `0.23.0.20260827` | 2026-08-27 (4 days ago) | 2026-09-03 (in 3 days) |
| [wcwidth](https://pypi.org/project/wcwidth/) | `0.8.2` | `0.8.3` | 2026-08-28 (3 days ago) | 2026-09-04 (in 4 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://repomatic.net/configuration) options:

- [`uv-lock.sync`](https://repomatic.net/configuration#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://repomatic.net/workflows#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`73928743`](https://github.com/kdeldycke/click-extra/commit/7392874395a111ce42aa8dd5f074519c496b642c)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/click-extra/blob/7392874395a111ce42aa8dd5f074519c496b642c/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/7392874395a111ce42aa8dd5f074519c496b642c/.github/workflows/autofix.yaml)
- **Run**: [#3317.1](https://github.com/kdeldycke/click-extra/actions/runs/33388066127)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.14.0`
