### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -773,11 +773,11 @@ wheels = [
 
 [[package]]
 name = "imagesize"
-version = "2.0.0"
+version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6c/e6/7bf14eeb8f8b7251141944835abd42eb20a658d89084b7e1f3e5fe394090/imagesize-2.0.0.tar.gz", hash = "sha256:8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3", size = 1773045, upload-time = "2026-03-03T14:18:29.941Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/5e/513ff06670c84e7b9887c1fdf61b2d42b4f574a831f2f1d2222023049d8a/imagesize-2.0.1.tar.gz", hash = "sha256:b2ba6a4dea487a7ebcd53248d3476aca449d30db12a2dde5e0c5ca9624fd77e5", size = 1883774, upload-time = "2026-08-24T12:35:19.13Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl", hash = "sha256:5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96", size = 9441, upload-time = "2026-03-03T14:18:27.892Z" },
+    { url = "https://files.pythonhosted.org/packages/01/f9/575c8d760eae1fc99651b7cc5efd96ad5379ca4d6b53750b0fb4fe983f34/imagesize-2.0.1-py3-none-any.whl", hash = "sha256:ea0c9a0384df69ed86a943a15cde37d0360b82491b3910dc2215e202e62b5b02", size = 14794, upload-time = "2026-08-24T12:35:12.548Z" },
 ]
 
 [[package]]
@@ -1127,11 +1127,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.11.3"
+version = "4.11.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b8/d7/e7bfbc86e9f99ff7807e24de7703f032e9c9ba80bb355cf26e0e9bc5a75e/platformdirs-4.11.3.tar.gz", hash = "sha256:66a73d38a849810252df809a3d8bcbda8e26f6c189920e7535ad608a48dbb5ab", size = 33050, upload-time = "2026-08-13T22:43:27.52Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/bb/ebc6636e1ae41314f796ebb7215fd28febb45f9aac72f2b04cb74b5071dc/platformdirs-4.11.4.tar.gz", hash = "sha256:f3373be828247211d0febabea97e238c3dfde8a60b3c90c32756fb52cb21556d", size = 34079, upload-time = "2026-08-24T14:53:49.676Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/a9/c34aebedd3a4c9afe5101b1b8713710b3fec18087c8a36c35d2f909861bd/platformdirs-4.11.3-py3-none-any.whl", hash = "sha256:5ed065d443751de711da036041a7a214122efc4a4de393b3f4137ba5576540e7", size = 23491, upload-time = "2026-08-13T22:43:26.121Z" },
+    { url = "https://files.pythonhosted.org/packages/28/be/0ff05fcd2938fb58ad9219bd54135968342d214737e012d62d43f06a2dd6/platformdirs-4.11.4-py3-none-any.whl", hash = "sha256:e34ff91a24bcddc6d939b878bdf3f5c437c9c46fe9e212b1bf455fdf1ee57586", size = 23741, upload-time = "2026-08-24T14:53:48.406Z" },
 ]
 
 [[package]]
@@ -1736,14 +1736,14 @@ wheels = [
 
 [[package]]
 name = "sphinx-autodoc-typehints"
-version = "3.13.2"
+version = "3.13.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" } },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/5f/7f2a768683c24dac122d6d9714b923ed84d87ffde058a37d525996687295/sphinx_autodoc_typehints-3.13.2.tar.gz", hash = "sha256:ea20b9a217b86391b0ece262c4336e3c2f476fe1f76028635d550b4e74cd7498", size = 88492, upload-time = "2026-08-03T22:26:01.344Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/87/71b5530a4657d5dda36742907d6ba77c63db724a9099eda5e114a62016b4/sphinx_autodoc_typehints-3.13.4.tar.gz", hash = "sha256:9429680faa192fec9797edb9575923177f9d2ab277481d561d4cbd4aeb9cd472", size = 92020, upload-time = "2026-08-24T15:37:44.181Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/53/7ae6f44d2a9275562ff6fb7cf8be14c35e8ab057ebd4954f9f10558efb0d/sphinx_autodoc_typehints-3.13.2-py3-none-any.whl", hash = "sha256:b2a7b531369a128c7c52867962fe224d89a1d480a462a314621c710a7d6e3ecf", size = 44836, upload-time = "2026-08-03T22:26:00.029Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/10/bc3e16cda1241b45f34bbec5e3728d386e45c831798d0e45da57d2023aae/sphinx_autodoc_typehints-3.13.4-py3-none-any.whl", hash = "sha256:05c9fa3bc312cb576a16a4b2e53459c170e540665687049a0d142a83736f5209", size = 45801, upload-time = "2026-08-24T15:37:43.004Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-08-24`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [imagesize](https://pypi.org/project/imagesize/) | [`2.0.0` → `2.0.1`](https://github.com/shibukawa/imagesize_py/compare/2.0.0...2.0.1) | 2026-08-24 (a week ago) |
| [platformdirs](https://pypi.org/project/platformdirs/) | [`4.11.3` → `4.11.4`](https://github.com/tox-dev/platformdirs/compare/4.11.3...4.11.4) | 2026-08-24 (a week ago) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | [`3.13.2` → `3.13.4`](https://github.com/tox-dev/sphinx-autodoc-typehints/compare/3.13.2...3.13.4) | 2026-08-24 (a week ago) |

### Release notes

<details>
<summary><code>imagesize</code></summary>

#### [`2.0.1`](https://github.com/shibukawa/imagesize_py/releases/tag/2.0.1)

- Optimize metadata parsing and HTTP range reads.
- Fix JPEG2000 box parsing.
- Accept single-quoted SVG dimensions.
- Return positive heights for top-down BMP images.
- Remove the upper Python version cap, migrate packaging to pyproject.toml,
  and add Python 3.15 CI coverage.
- Bump the package version to 2.0.1 and add recent feedback contributors to
  the README.

Related issues:
https://redirect.github.com/shibukawa/imagesize_py/issues/64
https://redirect.github.com/shibukawa/imagesize_py/issues/83
https://redirect.github.com/shibukawa/imagesize_py/issues/84

Related pull requests:
https://redirect.github.com/shibukawa/imagesize_py/pull/86
https://redirect.github.com/shibukawa/imagesize_py/pull/87
https://redirect.github.com/shibukawa/imagesize_py/pull/88
https://redirect.github.com/shibukawa/imagesize_py/pull/89
https://redirect.github.com/shibukawa/imagesize_py/pull/90
https://redirect.github.com/shibukawa/imagesize_py/pull/91
https://redirect.github.com/shibukawa/imagesize_py/pull/92

</details>

<details>
<summary><code>platformdirs</code></summary>

#### [`4.11.4`](https://github.com/tox-dev/platformdirs/releases/tag/4.11.4)

<!-- Release notes generated using configuration in .github/release.yaml at 4.11.4 -->

##### What's Changed
* 🔧 chore: batch dependency updates weekly on Tuesday by @​gaborbernat in https://redirect.github.com/tox-dev/platformdirs/pull/528
* fix: stop iter_*_dirs yielding the same directory twice by @​darrenhuai in https://redirect.github.com/tox-dev/platformdirs/pull/524
* docs: fix merge order in the config how-to by @​gaborbernat in https://redirect.github.com/tox-dev/platformdirs/pull/529

**Full Changelog**: https://redirect.github.com/tox-dev/platformdirs/compare/4.11.3...4.11.4

</details>

<details>
<summary><code>sphinx-autodoc-typehints</code></summary>

#### [`3.13.3`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.13.3)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

##### What's Changed
* 🔧 chore: batch dependency updates weekly on Tuesday by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/755
* 🐛 fix(parser): stop shadowing intersphinx roles in the rtype probe by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/756
* 🐛 fix(resolver): accept guarded code the interpreter rejects by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/757
* 🐛 fix(docstring): survive a re-entrant docstring handler by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/758

**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.13.2...3.13.3

#### [`3.13.4`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.13.4)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

##### What's Changed
* 🐛 fix(parser): stop shadowing intersphinx roles in the type role by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/761
* 🐛 fix(resolver): bind only what a guarded statement defines by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/760
* 🧪 test(docstring): pin what a nested handler restores by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/759

**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.13.3...3.13.4

</details>

## ❄️ Cooldown bypasses

Packages pulled in ahead of the cooldown by an [`exclude-newer-package`](https://docs.astral.sh/uv/reference/settings/#exclude-newer-package) freeze. Each entry is cleared from `pyproject.toml` automatically once its held version ages past the `exclude-newer` cutoff.

| Package | Held at | Held until |
| :-- | :-- | :-- |
| [click](https://pypi.org/project/click/) | `8.5.0` | 2026-09-02 (in 2 days) |

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [coverage](https://pypi.org/project/coverage/) | `7.15.4` | `7.16.0` | 2026-08-28 (3 days ago) | 2026-09-04 (in 4 days) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.6.0` | `13.7.0` | 2026-08-28 (3 days ago) | 2026-09-04 (in 4 days) |
| [platformdirs](https://pypi.org/project/platformdirs/) | `4.11.4` | `4.11.5` | 2026-08-27 (4 days ago) | 2026-09-03 (in 3 days) |
| [types-docutils](https://pypi.org/project/types-docutils/) | `0.22.3.20260724` | `0.23.0.20260827` | 2026-08-27 (4 days ago) | 2026-09-03 (in 3 days) |
| [wcwidth](https://pypi.org/project/wcwidth/) | `0.8.2` | `0.8.3` | 2026-08-28 (3 days ago) | 2026-09-04 (in 4 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://repomatic.net/configuration) options:

- [`uv-lock.sync`](https://repomatic.net/configuration#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://repomatic.net/workflows#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`da593bc8`](https://github.com/kdeldycke/click-extra/commit/da593bc89aa9c558135c75001507be8dd02a7d2c)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/click-extra/blob/da593bc89aa9c558135c75001507be8dd02a7d2c/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/da593bc89aa9c558135c75001507be8dd02a7d2c/.github/workflows/autofix.yaml)
- **Run**: [#3319.1](https://github.com/kdeldycke/click-extra/actions/runs/33410006376)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.14.0`
