### PR TITLE
Sync `uv.lock`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -318,12 +318,6 @@ dependency-groups.docs = { requires-python = ">= 3.14" }
 # Relative dates are fine here because the sync-uv-lock autofix job reverts
 # uv.lock when the only diff is timestamp noise.
 exclude-newer = "1 week"
-# Bypass the window above for Click 8.5.0, published 2026-08-26: without this
-# line uv resolves Click 8.4.2 until 2026-09-02. The cutoff exempts that one
-# release and turns inert once the window catches up, so delete it then. It
-# spells the instant in UTC because uv reads a bare date in the local zone,
-# which would lock a different timestamp on a runner than on a laptop.
-exclude-newer-package = { click = "2026-08-27T00:00:00Z" }
 # Package is at root level, not in "./src/".
 build-backend.module-root = ""
 build-backend.source-exclude = [

--- a/uv.lock
+++ b/uv.lock
@@ -12,9 +12,6 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P1W"
 
-[options.exclude-newer-package]
-click = "2026-08-27T00:00:00Z"
-
 [[package]]
 name = "accessible-pygments"
 version = "0.0.5"


### PR DESCRIPTION
## ❄️ Cooldown bypasses

Packages pulled in ahead of the cooldown by an [`exclude-newer-package`](https://docs.astral.sh/uv/reference/settings/#exclude-newer-package) freeze. Each entry is cleared from `pyproject.toml` automatically once its held version ages past the `exclude-newer` cutoff.

| Package | Held at | Held until |
| :-- | :-- | :-- |
| [click](https://pypi.org/project/click/) | 🧹 cleared: `8.5.0` | 2026-09-02 (just now) |

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [coverage](https://pypi.org/project/coverage/) | `7.15.4` | `7.16.0` | 2026-08-28 (5 days ago) | 2026-09-04 (in 2 days) |
| [deepmerge](https://pypi.org/project/deepmerge/) | `3.0` | `3.0.1` | 2026-09-01 (a day ago) | 2026-09-08 (in 6 days) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.6.0` | `13.7.0` | 2026-08-28 (5 days ago) | 2026-09-04 (in 2 days) |
| [platformdirs](https://pypi.org/project/platformdirs/) | `4.11.4` | `4.11.7` | 2026-09-01 (a day ago) | 2026-09-08 (in 6 days) |
| [pytest-randomly](https://pypi.org/project/pytest-randomly/) | `4.1.0` | `5.0.0` | 2026-09-01 (a day ago) | 2026-09-08 (in 6 days) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | `3.13.4` | `3.13.5` | 2026-09-01 (a day ago) | 2026-09-08 (in 6 days) |
| [sphinxcontrib-mermaid](https://pypi.org/project/sphinxcontrib-mermaid/) | `2.1.0` | `2.1.1` | 2026-09-01 (a day ago) | 2026-09-08 (in 6 days) |
| [types-docutils](https://pypi.org/project/types-docutils/) | `0.22.3.20260724` | `0.23.0.20260827` | 2026-08-27 (6 days ago) | 2026-09-03 (in a day) |
| [wcwidth](https://pypi.org/project/wcwidth/) | `0.8.2` | `0.8.3` | 2026-08-28 (5 days ago) | 2026-09-04 (in 2 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://repomatic.net/configuration) options:

- [`uv-lock.sync`](https://repomatic.net/configuration#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://repomatic.net/workflows#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`974ece8f`](https://github.com/kdeldycke/click-extra/commit/974ece8f5edb3969bac56eeab2996cc45d475346)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/click-extra/blob/974ece8f5edb3969bac56eeab2996cc45d475346/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/974ece8f5edb3969bac56eeab2996cc45d475346/.github/workflows/autofix.yaml)
- **Run**: [#3335.1](https://github.com/kdeldycke/click-extra/actions/runs/33640500244)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.14.0`
