### PR TITLE
Accept `kwargs` in `get_terminal_size` monkeypatch

### DIFF
--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1349,7 +1349,9 @@ def terminal_width(monkeypatch):
 
     def pin(columns: int) -> None:
         monkeypatch.setattr(
-            shutil, "get_terminal_size", lambda *_: os.terminal_size((columns, 24))
+            shutil,
+            "get_terminal_size",
+            lambda *args, **kwargs: os.terminal_size((columns, 24)),
         )
 
     return pin


### PR DESCRIPTION
`test_version` monkeypatches `shutil.get_terminal_size()` in a way that will only accept positional arguments, and not keyword arguments, leading to confusing tracebacks from pytest.

For example (cut for brevity):

```
INTERNALERROR>   File "/usr/lib/python3.14/site-packages/_pytest/_io/terminalwriter.py", line 96, in fullwidth
INTERNALERROR>     return get_terminal_width()
INTERNALERROR>   File "/usr/lib/python3.14/site-packages/_pytest/_io/terminalwriter.py", line 27, in get_terminal_width
INTERNALERROR>     width, _ = shutil.get_terminal_size(fallback=(80, 24))
INTERNALERROR>                ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
INTERNALERROR> TypeError: terminal_width.<locals>.pin.<locals>.<lambda>() got an unexpected keyword argument 'fallback'
```