### PR TITLE
Format Python

### DIFF
--- a/click_extra/color.py
+++ b/click_extra/color.py
@@ -247,7 +247,7 @@ def _colorfgbg_background(value: str) -> Literal["dark", "light"] | None:
     an integer.
     """
     try:
-        background_index = int(value.split(";")[-1])
+        background_index = int(value.rsplit(";", maxsplit=1)[-1])
     except ValueError:
         return None
     if background_index in _DARK_COLORFGBG_INDICES:

--- a/click_extra/config/schema.py
+++ b/click_extra/config/schema.py
@@ -601,7 +601,7 @@ def field_docstrings(cls: type) -> dict[str, str]:
 
 def _first_paragraph(text: str) -> str:
     """Collapse the first paragraph of `text` onto a single line."""
-    return " ".join(text.split("\n\n")[0].split())
+    return " ".join(text.split("\n\n", maxsplit=1)[0].split())
 
 
 def _field_config_key(field: Field) -> str:

--- a/click_extra/sphinx/click.py
+++ b/click_extra/sphinx/click.py
@@ -453,7 +453,7 @@ class ClickRunner(CliRunner):
         """Execute the given code, adding it to the runner's namespace."""
         code = compile_directive(directive)
         with patch_subprocess():
-            exec(code, self.namespace)  # noqa: S102
+            exec(code, self.namespace)
 
     def run_cli(self, directive: SphinxDirective) -> list[str]:
         """Execute the given `source_code`.
@@ -514,7 +514,7 @@ class ClickRunner(CliRunner):
                 )
 
         code = compile_directive(directive)
-        exec(code, self.namespace, local_vars)  # noqa: S102
+        exec(code, self.namespace, local_vars)
         return buffer
 
 

--- a/click_extra/sphinx/python.py
+++ b/click_extra/sphinx/python.py
@@ -164,7 +164,7 @@ class PythonRunner:
         `python:run` block).
         """
         self._locate(directive)
-        exec(compile_directive(directive), self.namespace)  # noqa: S102
+        exec(compile_directive(directive), self.namespace)
 
     def run_python(self, directive: ClickDirective) -> list[str]:
         """Execute the directive's content and capture `stdout`.
@@ -176,7 +176,7 @@ class PythonRunner:
         self._locate(directive)
         buffer = io.StringIO()
         with contextlib.redirect_stdout(buffer):
-            exec(compile_directive(directive), self.namespace)  # noqa: S102
+            exec(compile_directive(directive), self.namespace)
         return buffer.getvalue().splitlines()
 
 
@@ -461,7 +461,7 @@ def _execute_mirror_block(
     sys.path.insert(0, directory)
     try:
         with contextlib.redirect_stdout(buffer):
-            exec(code, namespace)  # noqa: S102
+            exec(code, namespace)
     finally:
         with contextlib.suppress(ValueError):
             sys.path.remove(directory)

--- a/click_extra/table.py
+++ b/click_extra/table.py
@@ -1661,7 +1661,7 @@ def select_row(
     Falls back to `canonical_ids` when `selected_ids` is empty / unset, so the
     row preserves its canonical column order in the absence of any user selection.
     """
-    ids = selected_ids if selected_ids else canonical_ids
+    ids = selected_ids or canonical_ids
     return tuple(row[col_id] for col_id in ids)
 
 

--- a/click_extra/version.py
+++ b/click_extra/version.py
@@ -553,7 +553,7 @@ def resolve_license(meta: PackageMetadata | None) -> str | None:
     for classifier in meta.get_all("Classifier") or []:
         text = str(classifier)
         if text.startswith("License ::"):
-            return text.split("::")[-1].strip()
+            return text.rsplit("::", maxsplit=1)[-1].strip()
 
     # Free-form legacy field (may hold the full license text).
     return meta_value(meta, "License")

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -2016,7 +2016,7 @@ def test_field_docstrings_returns_full_text():
 def test_field_docstrings_degrades_without_source():
     """A class defined through exec has no source: the mapping is empty."""
     namespace: dict = {}
-    exec(  # noqa: S102
+    exec(
         dedent("""
             from dataclasses import dataclass
 

--- a/tests/test_envvar.py
+++ b/tests/test_envvar.py
@@ -238,7 +238,7 @@ def envvars_test_cases():
         "0": False,
     }
     # No envvar value will have an effect on the flag if the envvar is not recognized.
-    broken_value_map = {k: False for k in working_value_map}
+    broken_value_map = dict.fromkeys(working_value_map, False)
 
     for (cmd_decorator, decorator_name), envvar_cases in matrix.items():
         for case_name, envvar_names in (

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -185,7 +185,7 @@ def test_command_default_color():
     auto default (ctx.color=None), yet a forced runner still renders ANSI codes."""
     runner = CliRunner()
     # Clear ambient color env vars so the auto default is deterministic.
-    env = {var: None for var in COLOR_ENVVARS}
+    env = dict.fromkeys(COLOR_ENVVARS)
     result = runner.invoke(run_cli_extra, color=True, env=env)
     assert result.exit_code == 0
     assert "\x1b[32mcolored output\x1b[0m" in result.stdout


### PR DESCRIPTION
> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/click-extra/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`format-python`](https://repomatic.net/workflows#format-python-format-python)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`080e6b6f`](https://github.com/kdeldycke/click-extra/commit/080e6b6fb6ec3c75d435754f6f9ee64d123073fb)
- **Job**: [`format-python`](https://github.com/kdeldycke/click-extra/blob/080e6b6fb6ec3c75d435754f6f9ee64d123073fb/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/click-extra/blob/080e6b6fb6ec3c75d435754f6f9ee64d123073fb/.github/workflows/autofix.yaml)
- **Run**: [#3364.1](https://github.com/kdeldycke/click-extra/actions/runs/34462901548)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.15.0`
